### PR TITLE
fixes XMLGenerator shared data bug

### DIFF
--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.hpp
@@ -222,7 +222,8 @@ void append_filter_control_operation
  * \param [in/out] aParentNode     pugi::xml_node
 **********************************************************************************/
 void append_filter_criterion_gradient_operation
-(const std::string& aSharedDataName,
+(const std::string& aInputSharedDataName,
+ const std::string& aOutputSharedDataName,
  pugi::xml_node& aParentNode);
 
 /******************************************************************************//**

--- a/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
@@ -27,6 +27,7 @@ void write_plato_main_operations_xml_file
 
     XMLGen::append_filter_options_to_plato_main_operation(aMetaData, tDocument);
     XMLGen::append_output_to_plato_main_operation(aMetaData, tDocument);
+    XMLGen::append_aggregator_operation(aMetaData, tDocument);
     XMLGen::append_initialize_field_to_plato_main_operation(aMetaData, tDocument);
     XMLGen::append_set_lower_bounds_to_plato_main_operation(aMetaData, tDocument);
     XMLGen::append_set_upper_bounds_to_plato_main_operation(aMetaData, tDocument);
@@ -290,6 +291,49 @@ void append_output_to_plato_main_operation
     XMLGen::append_stochastic_qoi_to_output_operation(aXMLMetaData, tOperation);
     XMLGen::append_deterministic_qoi_to_output_operation(aXMLMetaData, tOperation);
     XMLGen::append_surface_extraction_to_output_operation(aXMLMetaData, tOperation);
+}
+// function append_output_to_plato_main_operation
+/******************************************************************************/
+
+/******************************************************************************/
+void append_aggregator_operation
+(const XMLGen::InputData& aXMLMetaData,
+ pugi::xml_document &aDocument)
+{
+    if(aXMLMetaData.objectives.size() > 1)
+    {
+        auto tOperation = aDocument.append_child("Operation");
+        XMLGen::append_children({"Function", "Name"}, {"Aggregator", "AggregateEnergy"}, tOperation);
+        auto tAggregateNode = tOperation.append_child("Aggregate");
+        XMLGen::append_children({"Layout"}, {"Value"}, tAggregateNode);
+
+        for(auto tObjective : aXMLMetaData.objectives)
+        {
+            auto tInputNode = tAggregateNode.append_child("Input");
+            XMLGen::append_children({"ArgumentName"}, {"Value " + tObjective.name}, tInputNode);
+        }
+
+        auto tOutputNode = tAggregateNode.append_child("Output");
+        XMLGen::append_children({"ArgumentName"}, {"Value"}, tOutputNode);
+
+        tAggregateNode = tOperation.append_child("Aggregate");
+        XMLGen::append_children({"Layout"}, {"Nodal Field"}, tAggregateNode);
+        for(auto tObjective : aXMLMetaData.objectives)
+        {
+            auto tInputNode = tAggregateNode.append_child("Input");
+            XMLGen::append_children({"ArgumentName"}, {"Field " + tObjective.name}, tInputNode);
+        }
+
+        tOutputNode = tAggregateNode.append_child("Output");
+        XMLGen::append_children({"ArgumentName"}, {"Field"}, tOutputNode);
+
+        tOperation.append_child("Weighting");
+        for(auto tObjective : aXMLMetaData.objectives)
+        {
+            auto tInputNode = tAggregateNode.append_child("Weight");
+            XMLGen::append_children({"Value"}, {tObjective.weight}, tInputNode);
+        }
+    }
 }
 // function append_output_to_plato_main_operation
 /******************************************************************************/

--- a/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.hpp
@@ -151,6 +151,17 @@ void append_output_to_plato_main_operation
  pugi::xml_document &aDocument);
 
 /******************************************************************************//**
+ * \fn append_aggregator_operation
+ * \brief Append Plato main aggregator operation to PUGI XML document.
+ * \param [in]     aXMLMetaData Plato problem input data
+ * \param [in/out] aDocument    pugi::xml_document
+**********************************************************************************/
+void append_aggregator_operation
+(const XMLGen::InputData& aXMLMetaData,
+ pugi::xml_document &aDocument);
+
+
+/******************************************************************************//**
  * \fn append_stochastic_objective_value_to_plato_main_operation
  * \brief Append stochastic objective value operation to PUGI XML document.
  * \param [in]     aXMLMetaData Plato problem input data

--- a/base/src/input_generator/unittest/XMLGeneratorInterfaceFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorInterfaceFile_UnitTester.cpp
@@ -105,7 +105,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStage)
     XMLGen::InputData tMetaData;
     XMLGen::Objective tObjective;
     tObjective.name = "1";
-    tObjective.type = "compliance";
+    // tObjective.type = "compliance";
     tObjective.mPerformerName = "plato_analyze_1";
     tMetaData.objectives.push_back(tObjective);
 
@@ -117,9 +117,9 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStage)
     ASSERT_FALSE(tStage.empty());
     ASSERT_STREQ("Stage", tStage.name());
     auto tName = tStage.child("Name");
-    ASSERT_STREQ("Compute Objective Gradient ID-1", tName.child_value());
-    auto tType = tStage.child("Type");
-    ASSERT_STREQ("compliance", tType.child_value());
+    ASSERT_STREQ("Compute Objective Gradient", tName.child_value());
+    // auto tType = tStage.child("Type");
+    // ASSERT_STREQ("compliance", tType.child_value());
     auto tInput = tStage.child("Input");
     ASSERT_STREQ("Input", tInput.name());
     PlatoTestXMLGenerator::test_children({"SharedDataName"}, {"Control"}, tInput);
@@ -153,12 +153,12 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStage)
     tOpInputs = tOpInputs.next_sibling("Input");
     PlatoTestXMLGenerator::test_children({"ArgumentName", "SharedDataName"}, {"Gradient", "Objective Gradient ID-1"}, tOpInputs);
     tOpOutputs = tOperation.child("Output");
-    PlatoTestXMLGenerator::test_children({"ArgumentName", "SharedDataName"}, {"Filtered Gradient", "Objective Gradient ID-1"}, tOpOutputs);
+    PlatoTestXMLGenerator::test_children({"ArgumentName", "SharedDataName"}, {"Filtered Gradient", "Objective Gradient"}, tOpOutputs);
 
     // STAGE OUTPUT
     auto tOutput = tStage.child("Output");
     ASSERT_STREQ("Output", tOutput.name());
-    PlatoTestXMLGenerator::test_children({"SharedDataName"}, {"Objective Gradient ID-1"}, tOutput);
+    PlatoTestXMLGenerator::test_children({"SharedDataName"}, {"Objective Gradient"}, tOutput);
 }
 
 TEST(PlatoTestXMLGenerator, AppendObjectiveValueStage)
@@ -166,7 +166,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveValueStage)
     XMLGen::InputData tMetaData;
     XMLGen::Objective tObjective;
     tObjective.name = "1";
-    tObjective.type = "compliance";
+    // tObjective.type = "compliance";
     tObjective.mPerformerName = "plato_analyze_1";
     tMetaData.objectives.push_back(tObjective);
 
@@ -178,9 +178,9 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveValueStage)
     ASSERT_FALSE(tStage.empty());
     ASSERT_STREQ("Stage", tStage.name());
     auto tName = tStage.child("Name");
-    ASSERT_STREQ("Compute Objective Value ID-1", tName.child_value());
-    auto tType = tStage.child("Type");
-    ASSERT_STREQ("compliance", tType.child_value());
+    ASSERT_STREQ("Compute Objective Value", tName.child_value());
+    // auto tType = tStage.child("Type");
+    // ASSERT_STREQ("compliance", tType.child_value());
     auto tInput = tStage.child("Input");
     ASSERT_STREQ("Input", tInput.name());
     PlatoTestXMLGenerator::test_children({"SharedDataName"}, {"Control"}, tInput);
@@ -324,6 +324,13 @@ TEST(PlatoTestXMLGenerator, AppendSharedData)
     ASSERT_STREQ("SharedData", tSharedData.name());
     tKeys = {"Name", "Type", "Layout", "OwnerName", "UserName"};
     tValues = {"Objective Gradient ID-1", "Scalar", "Nodal Field", "plato_analyze_1", "platomain"};
+    PlatoTestXMLGenerator::test_children(tKeys, tValues, tSharedData);
+
+    tSharedData = tSharedData.next_sibling("SharedData");
+    ASSERT_FALSE(tSharedData.empty());
+    ASSERT_STREQ("SharedData", tSharedData.name());
+    tKeys = {"Name", "Type", "Layout", "OwnerName", "UserName"};
+    tValues = {"Objective Gradient", "Scalar", "Nodal Field", "platomain", "platomain"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tSharedData);
 
     tSharedData = tSharedData.next_sibling("SharedData");

--- a/base/src/input_generator/unittest/XMLGeneratorRandomInterfaceFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorRandomInterfaceFile_UnitTester.cpp
@@ -873,14 +873,19 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveSharedData)
     // TEST RESULTS AGAINST GOLD VALUES
     std::vector<std::string> tTemp = {"Name", "Type", "Layout", "Size", "OwnerName", "UserName"};
     std::vector<std::pair<std::string, std::vector<std::string>>> tGoldSharedDataKeys;
-    tGoldSharedDataKeys.push_back(std::make_pair("Objective Value", tTemp));
+    tGoldSharedDataKeys.push_back(std::make_pair("Objective Value ID-0", tTemp));
+    tTemp = {"Name", "Type", "Layout", "OwnerName", "UserName"};
+    tGoldSharedDataKeys.push_back(std::make_pair("Objective Gradient ID-0", tTemp));
     tTemp = {"Name", "Type", "Layout", "OwnerName", "UserName"};
     tGoldSharedDataKeys.push_back(std::make_pair("Objective Gradient", tTemp));
 
     tTemp = {"Objective Value ID-0", "Scalar", "Global", "1", "plato analyze", "platomain"};
     std::vector<std::pair<std::string, std::vector<std::string>>> tGoldSharedDataValues;
-    tGoldSharedDataValues.push_back(std::make_pair("Objective Value", tTemp));
+    tGoldSharedDataValues.push_back(std::make_pair("Objective Value ID-0", tTemp));
     tTemp = {"Objective Gradient ID-0", "Scalar", "Nodal Field", "plato analyze", "platomain"};
+    tGoldSharedDataValues.push_back(std::make_pair("Objective Gradient ID-0", tTemp));
+
+    tTemp = {"Objective Gradient", "Scalar", "Nodal Field", "plato analyze", "platomain"};
     tGoldSharedDataValues.push_back(std::make_pair("Objective Gradient", tTemp));
 
     auto tKeys = tGoldSharedDataKeys.begin();
@@ -1119,7 +1124,7 @@ TEST(PlatoTestXMLGenerator, AppendFilterCriterionGradientSamplesOperation)
 TEST(PlatoTestXMLGenerator, AppendFilterCriterionGradientOperation)
 {
     pugi::xml_document tDocument;
-    XMLGen::append_filter_criterion_gradient_operation("Objective Gradient", tDocument);
+    XMLGen::append_filter_criterion_gradient_operation("Objective Gradient", "Objective Gradient", tDocument);
     ASSERT_FALSE(tDocument.empty());
 
     // TEST RESULTS AGAINST GOLD VALUES
@@ -1921,8 +1926,8 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveValueStageForNondeterministicUsecase)
     // ****** 1) TEST RESULTS AGAINST STAGE GOLD VALUES ******
     auto tStage = tDocument.child("Stage");
     ASSERT_FALSE(tStage.empty());
-    std::vector<std::string> tGoldKeys = {"Name", "Type", "Input", "Operation", "For", "Operation", "Output"};
-    std::vector<std::string> tGoldValues = {"Compute Objective Value ID-0", "maximize stiffness", "", "", "", "", ""};
+    std::vector<std::string> tGoldKeys = {"Name", "Input", "Operation", "For", "Operation", "Output"};
+    std::vector<std::string> tGoldValues = {"Compute Objective Value", "", "", "", "", ""};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tStage);
 
     auto tStageInput= tStage.child("Input");
@@ -1934,7 +1939,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveValueStageForNondeterministicUsecase)
     auto tStageOutput= tStage.child("Output");
     ASSERT_FALSE(tStageOutput.empty());
     tGoldKeys = {"SharedDataName"};
-    tGoldValues = {"Objective Value ID-0"};
+    tGoldValues = {"Objective Value"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tStageOutput);
 
     // ****** 2) TEST RESULTS AGAINST FILTER OPERATION GOLD VALUES ******
@@ -2058,7 +2063,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveValueStageForNondeterministicUsecase)
     auto tRandomObjectiveOutput = tStageOperation.child("Output");
     ASSERT_FALSE(tRandomObjectiveOutput.empty());
     tGoldKeys = { "ArgumentName", "SharedDataName" };
-    tGoldValues = {"Objective Mean Plus 1 StdDev", "Objective Value ID-0"};
+    tGoldValues = {"Objective Mean Plus 1 StdDev", "Objective Value"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tRandomObjectiveOutput);
 }
 
@@ -2351,7 +2356,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStageForNondeterministicUseca
     auto tStage = tDocument.child("Stage");
     ASSERT_FALSE(tStage.empty());
     std::vector<std::string> tGoldKeys = {"Name", "Type", "Input", "Operation", "For", "For", "Operation", "Output"};
-    std::vector<std::string> tGoldValues = {"Compute Objective Gradient ID-0", "maximize stiffness", "", "", "", "", "", ""};
+    std::vector<std::string> tGoldValues = {"Compute Objective Gradient", "maximize stiffness", "", "", "", "", "", ""};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tStage);
 
     auto tStageInput= tStage.child("Input");
@@ -2363,7 +2368,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStageForNondeterministicUseca
     auto tStageOutput= tStage.child("Output");
     ASSERT_FALSE(tStageOutput.empty());
     tGoldKeys = {"SharedDataName"};
-    tGoldValues = {"Objective Gradient ID-0"};
+    tGoldValues = {"Objective Gradient"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tStageOutput);
 
     // ****** 2) TEST RESULTS AGAINST FILTER OPERATION GOLD VALUES ******
@@ -2492,7 +2497,7 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStageForNondeterministicUseca
     tOperationOutput = tStageOperation.child("Output");
     ASSERT_FALSE(tOperationOutput.empty());
     tGoldKeys = { "ArgumentName", "SharedDataName" };
-    tGoldValues = {"Objective Mean Plus 3 StdDev Gradient", "Objective Gradient ID-0"};
+    tGoldValues = {"Objective Mean Plus 3 StdDev Gradient", "Objective Gradient"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tOperationOutput);
 
     // ****** 5) TEST RESULTS AGAINST FILTER GRADIENT OPERATION GOLD VALUES ******
@@ -2511,13 +2516,13 @@ TEST(PlatoTestXMLGenerator, AppendObjectiveGradientStageForNondeterministicUseca
     tInput = tInput.next_sibling("Input");
     ASSERT_FALSE(tInput.empty());
     tGoldKeys = {"ArgumentName", "SharedDataName"};
-    tGoldValues = {"Gradient", "Objective Gradient ID-0"};
+    tGoldValues = {"Gradient", "Objective Gradient"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tInput);
     
     auto tOutput = tStageOperation.child("Output");
     ASSERT_FALSE(tOutput.empty());
     tGoldKeys = {"ArgumentName", "SharedDataName"};
-    tGoldValues = {"Filtered Gradient", "Objective Gradient ID-0"};
+    tGoldValues = {"Filtered Gradient", "Objective Gradient"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tOutput);
 }
 
@@ -2818,8 +2823,8 @@ TEST(PlatoTestXMLGenerator, AppendOptimizationObjectiveOptions)
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tOptimizerNode);
     auto tObjectiveNode = tOptimizerNode.child("Objective");
     tGoldKeys = {"ValueName", "ValueStageName", "GradientName", "GradientStageName"};
-    tGoldValues = {"Objective Value ID-0", "Compute Objective Value ID-0", "Objective Gradient ID-0",
-        "Compute Objective Gradient ID-0"};
+    tGoldValues = {"Objective Value ID-0", "Compute Objective Value", "Objective Gradient",
+        "Compute Objective Gradient"};
     PlatoTestXMLGenerator::test_children(tGoldKeys, tGoldValues, tObjectiveNode);
 }
 


### PR DESCRIPTION
Fixes bug with XMLGenerator that caused derivative checker to fail when aggregator was not being used.  I'm happy to go over it with you to explain the changes if you want.