### PR TITLE
Revert "added MPI_CXX_COMPILER variable"

### DIFF
--- a/base/src/contrib/msc/exo_obj/CMakeLists.txt
+++ b/base/src/contrib/msc/exo_obj/CMakeLists.txt
@@ -9,8 +9,6 @@ add_definitions(
 ###################################################################
 Plato_find_lib( EXODUS_LIB ON exodus ${SEACAS_PATH}/lib )
 
-SET(CMAKE_CXX_COMPILER ${MPI_CXX_COMPILER})
-
 ADD_EXECUTABLE(exo2obj src/exo-to-objs-tets-only.cpp)
 
 TARGET_LINK_LIBRARIES(exo2obj ${EXODUS_LIB})

--- a/examples/Analyze_ParallelESP/CMakeLists.txt
+++ b/examples/Analyze_ParallelESP/CMakeLists.txt
@@ -47,6 +47,7 @@ Plato_add_performer(PLATO_NEW_TEST ${ANALYZE_BINARY} ${ANALYZE_NP} ${LOCAL_COMM_
 
 # prepend pretest command
 set( PLATO_NEW_TEST ${PRETEST_COMMAND} ${PLATO_NEW_TEST} )
+message("WITH PRETEST: ${PLATO_NEW_TEST}")
 
 # Add the test
 set(INPUT_MESH SKIP_DECOMP)


### PR DESCRIPTION
Reverts platoengine/platoengine#25

exo2obj is added as a standalone now, so providing a 'host only' compiler isn't necessary.