### PR TITLE
Added reporting to Aggregator

### DIFF
--- a/apps/services/PlatoApp.cpp
+++ b/apps/services/PlatoApp.cpp
@@ -559,6 +559,17 @@ DistributedVector* PlatoApp::getNodeField(const std::string & aName)
     return tIterator->second;
 }
 
+std::string PlatoApp::getSharedDataName(const std::string & aName) const
+{
+    std::string tRetVal;
+    auto tIterator = mSharedDataNames.find(aName);
+    if(tIterator != mSharedDataNames.end())
+    {
+        tRetVal = tIterator->second;
+    }
+    return tRetVal;
+}
+
 size_t PlatoApp::getLocalNumElements() const
 {
     return mLightMp != nullptr ? mLightMp->getMesh()->getNumElems() : 0;

--- a/apps/services/PlatoApp.hpp
+++ b/apps/services/PlatoApp.hpp
@@ -176,6 +176,13 @@ public:
     Plato::TimersTree* getTimersTree();
 
     /******************************************************************************//**
+     * @brief Return shared data name
+     * @param [in] aName argument name
+     * @return shared data name
+    **********************************************************************************/
+    std::string getSharedDataName(const std::string & aName) const;
+
+    /******************************************************************************//**
      * @brief Return local number of elements
      * @param [in] aName field name
      * @return local number of elements
@@ -257,6 +264,8 @@ public:
     {
         if(aImportData.myLayout() == Plato::data::layout_t::SCALAR_FIELD)
         {
+            mSharedDataNames[aArgumentName] = aImportData.myName();
+
             DistributedVector* tLocalData = getNodeField(aArgumentName);
 
             int tMyLength = tLocalData->getEpetraVector()->MyLength();
@@ -273,6 +282,8 @@ public:
         }
         else if(aImportData.myLayout() == Plato::data::layout_t::ELEMENT_FIELD)
         {
+            mSharedDataNames[aArgumentName] = aImportData.myName();
+
             auto dataContainer = mLightMp->getDataContainer();
             double* tDataView;
             dataContainer->getVariable(getElementField(aArgumentName), tDataView);
@@ -287,6 +298,8 @@ public:
         }
         else if(aImportData.myLayout() == Plato::data::layout_t::SCALAR)
         {
+            mSharedDataNames[aArgumentName] = aImportData.myName();
+
             std::vector<double>* tLocalData = getValue(aArgumentName);
             tLocalData->resize(aImportData.size());
             aImportData.getData(*tLocalData);
@@ -303,6 +316,8 @@ public:
     {
         if(aExportData.myLayout() == Plato::data::layout_t::SCALAR_FIELD)
         {
+            mSharedDataNames[aArgumentName] = aExportData.myName();
+
             DistributedVector* tLocalData = getNodeField(aArgumentName);
 
             tLocalData->LocalExport();
@@ -318,6 +333,8 @@ public:
         }
         else if(aExportData.myLayout() == Plato::data::layout_t::ELEMENT_FIELD)
         {
+            mSharedDataNames[aArgumentName] = aExportData.myName();
+
             auto dataContainer = mLightMp->getDataContainer();
             double* tDataView;
             dataContainer->getVariable(getElementField(aArgumentName), tDataView);
@@ -331,6 +348,8 @@ public:
         }
         else if(aExportData.myLayout() == Plato::data::layout_t::SCALAR)
         {
+            mSharedDataNames[aArgumentName] = aExportData.myName();
+
             std::vector<double>* tLocalData = getValue(aArgumentName);
             if(int(tLocalData->size()) == aExportData.size())
             {
@@ -355,7 +374,7 @@ private:
      * @param [in] aValueMap name-data map
     **********************************************************************************/
     template<typename ValueType>
-    void throwParsingException(const std::string & aName, const std::map<std::string, ValueType> & aValueMap)
+    void throwParsingException(const std::string & aName, const std::map<std::string, ValueType> & aValueMap) const
     {
         std::stringstream tMessage;
         tMessage << "Cannot find specified Argument: " << aName.c_str() << std::endl;
@@ -394,6 +413,7 @@ private:
     std::map<std::string,std::shared_ptr<Plato::MLSstruct>> mMLS;  /*!< Moving Least Squared (MLS) metadata */
 #endif
 
+    std::map<std::string, std::string> mSharedDataNames; /*!< Argument name -> SharedData name */
     std::map<std::string, VarIndex> mElementFieldMap; /*!< Name - Element Field map */
     std::map<std::string, DistributedVector*> mNodeFieldMap; /*!< Name - Node Field map */
     std::map<std::string, std::vector<double>*> mValueMap; /*!< Name - Scalar values map */

--- a/apps/services/ServicesPythonModule.cpp
+++ b/apps/services/ServicesPythonModule.cpp
@@ -58,8 +58,8 @@ namespace ServicesPython
 
 class SharedData {
   public:
-    SharedData(Plato::data::layout_t layout, int size, double initVal=0.0 ) :
-      m_data(size,initVal), m_layout(layout){}
+    SharedData(Plato::data::layout_t layout, int size, double initVal=0.0, std::string name=std::string() ) :
+      m_data(size,initVal), m_layout(layout), m_name(name) {}
 
     void setData(const std::vector<double> & aData)
     {
@@ -72,6 +72,10 @@ class SharedData {
     int size() const
     {
       return m_data.size();
+    }
+    std::string myName() const
+    {
+      return m_name;
     }
 
     std::string myContext() const {return m_context;}
@@ -88,6 +92,7 @@ class SharedData {
     std::vector<double> m_data;
     Plato::data::layout_t m_layout;
     std::string m_context;
+    std::string m_name;
 };
 class NodeField : public SharedData
 {

--- a/base/src/operations/Plato_Aggregator.cpp
+++ b/base/src/operations/Plato_Aggregator.cpp
@@ -58,6 +58,8 @@ namespace Plato
 Aggregator::Aggregator(PlatoApp* aPlatoApp, Plato::InputData& aNode) :
         Plato::LocalOp(aPlatoApp)
 {
+    mReportStatus = Get::Bool(aNode, "Report", false);
+
     Plato::InputData tWeightNode = Plato::Get::InputData(aNode, "Weighting");
     for(auto tNode : tWeightNode.getByName<Plato::InputData>("Weight"))
     {
@@ -104,6 +106,20 @@ Aggregator::Aggregator(PlatoApp* aPlatoApp, Plato::InputData& aNode) :
     }
 }
 
+void Aggregator::reportStatus(const std::stringstream& aStream) const
+{
+    reportStatus(aStream.str());
+}
+
+void Aggregator::reportStatus(const std::string& aString) const
+{
+    if(mReportStatus)
+    {
+        Plato::Console::Alert(aString);
+    }
+}
+
+
 void Aggregator::operator()()
 {
     // begin timer if timing
@@ -112,7 +128,201 @@ void Aggregator::operator()()
         mPlatoApp->getTimersTree()->begin_partition(Plato::timer_partition_t::timer_partition_t::aggregator);
     }
 
-    std::vector<double> tWeights(mWeights);
+    auto tWeights = getWeights();
+
+    reportStatus("#--- Aggregator ----------------------------------------------------------------");
+    for(AggStruct& tMyAggStruct : mAggStructs)
+    {
+        aggregate(tMyAggStruct, tWeights);
+    }
+    reportStatus("#-------------------------------------------------------------------------------");
+
+    // end: "aggregator"
+    if(mPlatoApp->getTimersTree())
+    {
+        mPlatoApp->getTimersTree()->end_partition();
+    }
+
+    return;
+}
+
+void Aggregator::aggregateScalarField(const AggStruct& aAggStruct, const decltype(mWeights)& aWeights)
+{
+    using std::setw;
+    using std::setprecision;
+
+    const int fw = 10; // field width
+    const int pn = 4;  // precision
+
+    std::stringstream tMessage;
+    tMessage << "# Scalar Field";
+    reportStatus(tMessage.str());
+    tMessage.str(std::string());
+    tMessage << "#";
+    tMessage << setw(fw) << "Input";
+    tMessage << setw(fw) << "Norm";
+    tMessage << setw(fw) << "Weight";
+    if(!mWeightNormals.empty())
+    {
+        tMessage << setw(fw) << "Normal";
+        tMessage << setw(fw) << "Adj Wt";
+    }
+    tMessage << setw(fw) << "Weighted";
+    tMessage << setw(fw) << "Name";
+    reportStatus(tMessage.str());
+
+    auto& tField = *(mPlatoApp->getNodeField(aAggStruct.mOutputName));
+    double* tToData;
+    tField.ExtractView(&tToData);
+    int tDataLength = tField.MyLength();
+
+    int tNvals = aAggStruct.mInputNames.size();
+    std::vector<double*> tFromData(tNvals);
+    for(int tIval = 0; tIval < tNvals; tIval++)
+    {
+        auto tPfield = mPlatoApp->getNodeField(aAggStruct.mInputNames[tIval]);
+        tPfield->ExtractView(&tFromData[tIval]);
+
+    }
+
+    std::vector<double> tFromDataNorm(tNvals, 0.0);
+    for(int tIndex = 0; tIndex < tDataLength; tIndex++)
+    {
+        tToData[tIndex] = 0.0;
+        for(int tIval = 0; tIval < tNvals; tIval++)
+        {
+            tToData[tIndex] += tFromData[tIval][tIndex] * aWeights[tIval];
+            tFromDataNorm[tIval] += tFromData[tIval][tIndex]*tFromData[tIval][tIndex];
+        }
+    }
+    for(int tIval = 0; tIval < tNvals; tIval++)
+    {
+        if(tFromDataNorm[tIval] != 0.0)
+        {
+            tFromDataNorm[tIval] = sqrt(tFromDataNorm[tIval]);
+        }
+
+        auto tInputName = mPlatoApp->getSharedDataName(aAggStruct.mInputNames[tIval]);
+        std::stringstream tMessage;
+        tMessage << "#";
+        tMessage << setw(fw) << tIval;
+        tMessage << setw(fw) << setprecision(pn) << tFromDataNorm[tIval];
+        tMessage << setw(fw) << setprecision(pn) << mWeights[tIval];
+        if(!mWeightNormals.empty())
+        {
+            std::vector<double>* data = mPlatoApp->getValue(mWeightNormals[tIval]);
+            tMessage << setw(fw) << setprecision(pn) << *(data->data());
+            tMessage << setw(fw) << setprecision(pn) << aWeights[tIval];
+        }
+        tMessage << setw(fw) << setprecision(pn) << tFromDataNorm[tIval]*aWeights[tIval];
+        tMessage << "      " << tInputName;
+        reportStatus(tMessage.str());
+    }
+}
+
+void Aggregator::aggregateScalar(const AggStruct& aAggStruct, const decltype(mWeights)& aWeights)
+{
+    using std::setw;
+    using std::setprecision;
+
+    const int fw = 10;
+    const int pn = 4;
+
+    std::stringstream tMessage;
+    tMessage << "# Scalar";
+    reportStatus(tMessage.str());
+    tMessage.str(std::string());
+    tMessage << "#";
+    tMessage << setw(fw) << "Input";
+    tMessage << setw(fw) << "Value";
+    tMessage << setw(fw) << "Weight";
+    if(!mWeightNormals.empty())
+    {
+        tMessage << setw(fw) << "Normal";
+        tMessage << setw(fw) << "Adj Wt";
+    }
+    tMessage << setw(fw) << "Weighted";
+    tMessage << setw(fw) << "Name";
+    reportStatus(tMessage.str());
+
+    std::vector<double>& tToData = *(mPlatoApp->getValue(aAggStruct.mOutputName));
+
+    unsigned int tDataLength = 0;
+    int tNvals = aAggStruct.mInputNames.size();
+    std::vector<double*> tFromData(tNvals);
+
+    // read first input value
+    std::vector<double>* tMyValue = mPlatoApp->getValue(aAggStruct.mInputNames[0]);
+    tFromData[0] = tMyValue->data();
+    tDataLength = tMyValue->size();
+
+    // read remaining input values
+    for(int tIval = 1; tIval < tNvals; tIval++)
+    {
+        tMyValue = mPlatoApp->getValue(aAggStruct.mInputNames[tIval]);
+        tFromData[tIval] = tMyValue->data();
+        if(tMyValue->size() != tDataLength)
+        {
+            throw ParsingException("PlatoApp::Aggregator: attempted to aggregate vectors of differing lengths.");
+        }
+    }
+
+    tToData.resize(tDataLength);
+    std::fill(tToData.begin(), tToData.end(), 0.0);
+    for(unsigned int tIndex = 0; tIndex < tDataLength; tIndex++)
+    {
+        for(int tIval = 0; tIval < tNvals; tIval++)
+        {
+            auto tInputName = mPlatoApp->getSharedDataName(aAggStruct.mInputNames[tIval]);
+            std::stringstream tMessage;
+            tMessage << "#";
+            tMessage << setw(fw) << tIval;
+            tMessage << setw(fw) << setprecision(pn) << tFromData[tIval][tIndex];
+            tMessage << setw(fw) << setprecision(pn) << mWeights[tIval];
+            if(!mWeightNormals.empty())
+            {
+                std::vector<double>* data = mPlatoApp->getValue(mWeightNormals[tIval]);
+                tMessage << setw(fw) << setprecision(pn) << *(data->data());
+                tMessage << setw(fw) << setprecision(pn) << aWeights[tIval];
+            }
+            tMessage << setw(fw) << setprecision(pn) << tFromData[tIval][tIndex]*aWeights[tIval];
+            tMessage << "      " << tInputName;
+            reportStatus(tMessage);
+
+            tToData[tIndex] += tFromData[tIval][tIndex] * aWeights[tIval];
+        }
+
+        std::stringstream tMessage;
+        tMessage << "#";
+        tMessage << setw(fw) << "Output";
+        tMessage << setw(fw) << setprecision(pn) << tToData[tIndex];
+        reportStatus(tMessage);
+    }
+}
+
+void Aggregator::aggregate(const AggStruct& aAggStruct, decltype(mWeights) aWeights)
+{
+    if(aAggStruct.mLayout == Plato::data::layout_t::SCALAR_FIELD)
+    {
+        aggregateScalarField(aAggStruct, aWeights);
+    }
+    else if(aAggStruct.mLayout == Plato::data::layout_t::SCALAR)
+    {
+        aggregateScalar(aAggStruct, aWeights);
+    }
+    else
+    {
+        std::stringstream tMessage;
+        tMessage << "Unknown 'Layout' (" << aAggStruct.mLayout << ") specified in PlatoApp::Aggregator."
+                 << std::endl;
+        Plato::ParsingException tParsingException(tMessage.str());
+        throw tParsingException;
+    }
+}
+
+decltype(Aggregator::mWeights) Aggregator::getWeights()
+{
+    decltype(mWeights) tWeights(mWeights);
     if(!mWeightBases.empty())
     {
         int tNvals = mWeightBases.size();
@@ -171,90 +381,7 @@ void Aggregator::operator()()
             }
         }
     }
-
-    for(AggStruct& tMyAggStruct : mAggStructs)
-    {
-
-        if(tMyAggStruct.mLayout == Plato::data::layout_t::SCALAR_FIELD)
-        {
-
-            auto& tField = *(mPlatoApp->getNodeField(tMyAggStruct.mOutputName));
-            double* tToData;
-            tField.ExtractView(&tToData);
-            int tDataLength = tField.MyLength();
-
-            int tNvals = tMyAggStruct.mInputNames.size();
-            std::vector<double*> tFromData(tNvals);
-            for(int tIval = 0; tIval < tNvals; tIval++)
-            {
-                auto tPfield = mPlatoApp->getNodeField(tMyAggStruct.mInputNames[tIval]);
-                tPfield->ExtractView(&tFromData[tIval]);
-            }
-
-            for(int tIndex = 0; tIndex < tDataLength; tIndex++)
-            {
-                tToData[tIndex] = 0.0;
-                for(int j = 0; j < tNvals; j++)
-                {
-                    tToData[tIndex] += tFromData[j][tIndex] * tWeights[j];
-                }
-            }
-
-        }
-        else if(tMyAggStruct.mLayout == Plato::data::layout_t::SCALAR)
-        {
-
-            std::vector<double>& tToData = *(mPlatoApp->getValue(tMyAggStruct.mOutputName));
-
-            unsigned int tDataLength = 0;
-            int tNvals = tMyAggStruct.mInputNames.size();
-            std::vector<double*> tFromData(tNvals);
-
-            // read first input value
-            std::vector<double>* tMyValue = mPlatoApp->getValue(tMyAggStruct.mInputNames[0]);
-            tFromData[0] = tMyValue->data();
-            tDataLength = tMyValue->size();
-
-            // read remaining input values
-            for(int tIval = 1; tIval < tNvals; tIval++)
-            {
-                tMyValue = mPlatoApp->getValue(tMyAggStruct.mInputNames[tIval]);
-                tFromData[tIval] = tMyValue->data();
-                if(tMyValue->size() != tDataLength)
-                {
-                    throw ParsingException("PlatoApp::Aggregator: attempted to aggregate vectors of differing lengths.");
-                }
-            }
-
-            tToData.resize(tDataLength);
-            for(unsigned int tIndex = 0; tIndex < tDataLength; tIndex++)
-            {
-                tToData[tIndex] = 0.0;
-                for(int j = 0; j < tNvals; j++)
-                {
-                    tToData[tIndex] += tFromData[j][tIndex] * tWeights[j];
-                }
-            }
-
-        }
-        else
-        {
-
-            std::stringstream tMessage;
-            tMessage << "Unknown 'Layout' (" << tMyAggStruct.mLayout << ") specified in PlatoApp::Aggregator."
-                     << std::endl;
-            Plato::ParsingException tParsingException(tMessage.str());
-            throw tParsingException;
-        }
-    }
-
-    // end: "aggregator"
-    if(mPlatoApp->getTimersTree())
-    {
-        mPlatoApp->getTimersTree()->end_partition();
-    }
-
-    return;
+    return tWeights;
 }
 
 void Aggregator::getArguments(std::vector<Plato::LocalArg> & aLocalArgs)

--- a/base/src/operations/Plato_Aggregator.hpp
+++ b/base/src/operations/Plato_Aggregator.hpp
@@ -48,6 +48,7 @@
 
 #pragma once
 
+#include "Plato_Console.hpp"
 #include "Plato_LocalOperation.hpp"
 
 namespace Plato
@@ -87,12 +88,50 @@ private:
         std::vector<std::string> mInputNames; /*!< input argument name */
     };
 
+    bool mReportStatus; /*!< whether to write status to Plato::Console */
     double mLimitWeight; /*!< weight's upper bound */
     std::vector<std::string> mWeightBases; /*!< weight bases */
     std::vector<std::string> mWeightNormals; /*!< weight normals */
     std::string mWeightMethod; /*!< method - basically, how are weights applied */
     std::vector<double> mWeights; /*!< weights for each component */
     std::vector<AggStruct> mAggStructs; /*!< core data for each aggregated component */
+
+    /******************************************************************************//**
+     * @brief Return aggregator weights
+    **********************************************************************************/
+    decltype(mWeights) getWeights();
+
+    /******************************************************************************//**
+     * @brief Aggregate the member scalars and scalar fields
+     * @param [in] aWeights current weights
+    **********************************************************************************/
+    void aggregate(const AggStruct& aAggStruct, decltype(mWeights) aWeights);
+
+    /******************************************************************************//**
+     * @brief Aggregate a scalar field
+     * @param [in] aAggStruct struct containing inputs and output
+     * @param [in] aWeights current weights
+    **********************************************************************************/
+    void aggregateScalarField(const AggStruct& aAggStruct, const decltype(mWeights)& aWeights);
+
+    /******************************************************************************//**
+     * @brief Aggregate a scalar
+     * @param [in] aAggStruct struct containing inputs and output
+     * @param [in] aWeights current weights
+    **********************************************************************************/
+    void aggregateScalar(const AggStruct& aAggStruct, const decltype(mWeights)& aWeights);
+
+    /******************************************************************************//**
+     * @brief Wrapper around Plato::Console::Alert()
+     * @param [in] aStream stream containing message for console
+    **********************************************************************************/
+    void reportStatus(const std::stringstream& aStream) const;
+
+    /******************************************************************************//**
+     * @brief Wrapper around Plato::Console::Alert()
+     * @param [in] aString string containing message for console
+    **********************************************************************************/
+    void reportStatus(const std::string& aStream) const;
 };
 // class Aggregator
 

--- a/examples/Analyze_2Phys_Sym/interface.xml
+++ b/examples/Analyze_2Phys_Sym/interface.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<Console>
+  <Enabled>true</Enabled>
+</Console>
 
 <Performer> 
   <Name>PlatoMain</Name>
@@ -440,7 +443,7 @@
   </Operation>
 
   <Operation>
-    <Name>Aggregate</Name>
+    <Name>Aggregate Value</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Value 1</ArgumentName>
@@ -500,7 +503,7 @@
   </Operation>
 
   <Operation>
-    <Name>Aggregate</Name>
+    <Name>Aggregate Gradient</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Field 1</ArgumentName>

--- a/examples/Analyze_2Phys_Sym/platoApp.xml
+++ b/examples/Analyze_2Phys_Sym/platoApp.xml
@@ -114,8 +114,9 @@
 </Operation>
 
 <Operation>
+  <Name>Aggregate Value</Name>
   <Function>Aggregator</Function>
-  <Name>Aggregate</Name>
+  <Report>true</Report>
   <Aggregate>
     <Layout>Value</Layout>
     <Input>
@@ -128,6 +129,18 @@
       <ArgumentName>Value</ArgumentName>
     </Output>
   </Aggregate>
+  <Weighting>
+    <Weight> <Value>0.25</Value> </Weight>
+    <Weight> <Value>0.75</Value> </Weight>
+    <Normals>
+      <Input><ArgumentName>Normal 1</ArgumentName></Input>
+      <Input><ArgumentName>Normal 2</ArgumentName></Input>
+    </Normals>
+  </Weighting>
+</Operation>
+<Operation>
+  <Name>Aggregate Gradient</Name>
+  <Function>Aggregator</Function>
   <Aggregate>
     <Layout>Nodal Field</Layout>
     <Input>

--- a/examples/Analyze_CompMin3D/interface.xml
+++ b/examples/Analyze_CompMin3D/interface.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 
+<Console>
+  <Enabled>true</Enabled>
+</Console>
+
 <Performer> 
   <Name>PlatoMain</Name>
   <Code>Plato_Main</Code>
@@ -422,7 +426,7 @@
   </Operation>
 
   <Operation>
-    <Name>AggregateEnergy</Name>
+    <Name>AggregateEnergyValue</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Value 1</ArgumentName>
@@ -479,7 +483,7 @@
   </Operation>
 
   <Operation>
-    <Name>AggregateEnergy</Name>
+    <Name>AggregateEnergyGradient</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Field 1</ArgumentName>

--- a/examples/Analyze_CompMin3D/platoApp.xml
+++ b/examples/Analyze_CompMin3D/platoApp.xml
@@ -120,8 +120,9 @@
 </Operation>
 
 <Operation>
+  <Name>AggregateEnergyValue</Name>
   <Function>Aggregator</Function>
-  <Name>AggregateEnergy</Name>
+  <Report>true</Report>
   <Aggregate>
     <Layout>Value</Layout>
     <Input>
@@ -131,6 +132,16 @@
       <ArgumentName>Value</ArgumentName>
     </Output>
   </Aggregate>
+  <Weighting>
+    <Weight>
+      <Value>1.00</Value>
+    </Weight>
+  </Weighting>
+</Operation>
+
+<Operation>
+  <Name>AggregateEnergyGradient</Name>
+  <Function>Aggregator</Function>
   <Aggregate>
     <Layout>Nodal Field</Layout>
     <Input>
@@ -146,6 +157,7 @@
     </Weight>
   </Weighting>
 </Operation>
+
 <Operation>
   <Function>SetLowerBounds</Function>
   <Name>Calculate Lower Bounds</Name>

--- a/examples/Analyze_Disp_Opt/interface.xml
+++ b/examples/Analyze_Disp_Opt/interface.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 
+<Console>
+  <Enabled>true</Enabled>
+</Console>
+
 <Performer> 
   <Name>PlatoMain</Name>
   <Code>Plato_Main</Code>

--- a/examples/Analyze_Disp_Opt/platoApp.xml
+++ b/examples/Analyze_Disp_Opt/platoApp.xml
@@ -111,6 +111,7 @@
 <Operation>
   <Function>Aggregator</Function>
   <Name>AggregateEnergy</Name>
+  <Report>true</Report>
   <Aggregate>
     <Layout>Value</Layout>
     <Input>

--- a/examples/Analyze_Thermal_Opt/interface.xml
+++ b/examples/Analyze_Thermal_Opt/interface.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 
+<Console>
+  <Enabled>true</Enabled>
+</Console>
+
 <Performer> 
   <Name>PlatoMain</Name>
   <Code>Plato_Main</Code>

--- a/examples/Analyze_Thermal_Opt/platoApp.xml
+++ b/examples/Analyze_Thermal_Opt/platoApp.xml
@@ -113,6 +113,7 @@
 <Operation>
   <Function>Aggregator</Function>
   <Name>AggregateValue</Name>
+  <Report>true</Report>
   <Aggregate>
     <Layout>Value</Layout>
     <Input><ArgumentName>Value 1</ArgumentName></Input>

--- a/examples/Analyze_TransMech_Opt/interface.xml
+++ b/examples/Analyze_TransMech_Opt/interface.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 
+<Console>
+  <Enabled>true</Enabled>
+</Console>
+
 <Performer> 
   <Name>PlatoMain</Name>
   <Code>Plato_Main</Code>
@@ -422,7 +426,7 @@
   </Operation>
 
   <Operation>
-    <Name>AggregateEnergy</Name>
+    <Name>AggregateEnergyValue</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Value 1</ArgumentName>
@@ -471,7 +475,7 @@
   </Operation>
 
   <Operation>
-    <Name>AggregateEnergy</Name>
+    <Name>AggregateEnergyGradient</Name>
     <PerformerName>PlatoMain</PerformerName>
     <Input>
       <ArgumentName>Field 1</ArgumentName>

--- a/examples/Analyze_TransMech_Opt/platoApp.xml
+++ b/examples/Analyze_TransMech_Opt/platoApp.xml
@@ -113,8 +113,9 @@
 </Operation>
 
 <Operation>
+  <Name>AggregateEnergyValue</Name>
   <Function>Aggregator</Function>
-  <Name>AggregateEnergy</Name>
+  <Report>true</Report>
   <Aggregate>
     <Layout>Value</Layout>
     <Input>
@@ -124,6 +125,16 @@
       <ArgumentName>Value</ArgumentName>
     </Output>
   </Aggregate>
+  <Weighting>
+    <Weight>
+      <Value>1.00</Value>
+    </Weight>
+  </Weighting>
+</Operation>
+
+<Operation>
+  <Name>AggregateEnergyGradient</Name>
+  <Function>Aggregator</Function>
   <Aggregate>
     <Layout>Nodal Field</Layout>
     <Input>
@@ -139,6 +150,7 @@
     </Weight>
   </Weighting>
 </Operation>
+
 <Operation>
   <Function>SetLowerBounds</Function>
   <Name>Calculate Lower Bounds</Name>


### PR DESCRIPTION
Added '```<Report>true</Report>```' keyword to Aggregator Operation.  See Analyze_CompMin3D for an example.  If the Console is enabled (i.e., ```<Console><Enabled>true</Enabled></Console>``` is in the interface file), the following information is written to the console each time the aggregator is called:
```shell
#--- Aggregator ----------------------------------------------------------------
# Scalar
#     Input     Value    Weight    Normal    Adj Wt  Weighted      Name
#         0      9780      0.25      7394 3.381e-05    0.3307      Objective 1
#         1   0.02541      0.75   0.04142     18.11    0.4601      Objective 2
#    Output    0.7908
#-------------------------------------------------------------------------------
```
