### PR TITLE
added graceful termination using 'plato.control' file

### DIFF
--- a/base/src/interface/Plato_Interface.hpp
+++ b/base/src/interface/Plato_Interface.hpp
@@ -126,6 +126,7 @@ public:
     void registerException();
     void registerException(Plato::ParsingException aParsingException);
     void registerException(Plato::LogicException aLogicException);
+    void registerException(Plato::TerminateSignal aTerminateSignal);
 
     // control
     bool isDone();

--- a/base/src/tools/Plato_Exceptions.cpp
+++ b/base/src/tools/Plato_Exceptions.cpp
@@ -69,6 +69,10 @@ void ExceptionHandler::Catch()
     {
         this->registerException(tLogicException);
     }
+    catch(const TerminateSignal & tTerminateSignal)
+    {
+        this->registerException(tTerminateSignal);
+    }
     catch(std::exception const& any_std_exception)
     {
         this->registerException(any_std_exception);
@@ -185,6 +189,20 @@ void ExceptionHandler::registerException(const Plato::LogicException & aLogicExc
 }
 
 /******************************************************************************/
+void ExceptionHandler::registerException(const Plato::TerminateSignal & aTerminateSignal)
+/******************************************************************************/
+{
+    this->setError();
+    if(mMyPID == 0)
+    {
+        mErrorStream << " -----------------------------------------------------------------------------" << std::endl;
+        mErrorStream << "  Terminate signal received on Performer '" << mMyCommName << "': " << std::endl;
+        mErrorStream << "  " << aTerminateSignal.message();
+        mErrorStream << " -----------------------------------------------------------------------------" << std::endl;
+    }
+}
+
+/******************************************************************************/
 void ExceptionHandler::handleExceptions()
 /******************************************************************************/
 {
@@ -213,6 +231,13 @@ std::string LogicException::message() const
 {
     std::stringstream errorStream;
     errorStream << "  Error message: " << mMessage << std::endl;
+    return errorStream.str();
+}
+
+std::string TerminateSignal::message() const
+{
+    std::stringstream errorStream;
+    errorStream << "  Message: " << mMessage << std::endl;
     return errorStream.str();
 }
 
@@ -259,4 +284,10 @@ LogicException::LogicException(const std::string & aMessage) :
 {
 }
 
+/******************************************************************************/
+TerminateSignal::TerminateSignal(const std::string & aMessage) :
+        mMessage(aMessage)
+/******************************************************************************/
+{
+}
 } // End namespace Plato

--- a/base/src/tools/Plato_Exceptions.hpp
+++ b/base/src/tools/Plato_Exceptions.hpp
@@ -84,6 +84,16 @@ private:
     std::string mMessage;
 };
 
+class TerminateSignal
+{
+public:
+    explicit TerminateSignal(const std::string & aMessage);
+    std::string message() const;
+
+private:
+    std::string mMessage;
+};
+
 /******************************************************************************/
 //!  Exception handler class.
 /*!
@@ -101,6 +111,7 @@ public:
 
     void registerException(const Plato::ParsingException & aParsingException);
     void registerException(const Plato::LogicException & aLogicException);
+    void registerException(const Plato::TerminateSignal & aTerminateSignal);
     void registerException(const std::exception& any_std_exception);
     void registerException();
 


### PR DESCRIPTION
To gracefully terminate a running plato job (i.e., without cntrl^C or using scheduler, etc) create a file 'plato.control' with the line ```<Terminate>true</Terminate>``` in the run directory.  This stops the job with the following written to the console:
```
 -----------------------------------------------------------------------------
  Terminate signal received on Performer 'PlatoMain': 
    Message: 

 INFO: Interface::broadcastStageIndex: Terminate stage requested.  Exiting.


 -----------------------------------------------------------------------------
```