### PR TITLE
added try-catch around call to perform() in platoesp main()

### DIFF
--- a/apps/esp/PlatoESPApp.hpp
+++ b/apps/esp/PlatoESPApp.hpp
@@ -263,7 +263,14 @@ int Main(int aArgc, char *aArgv[])
         safeExit();
     }
 
-    tPlatoInterface->perform();
+    try
+    {
+      tPlatoInterface->perform();
+    }
+    catch(...)
+    {
+        safeExit();
+    }
 
     if(tApp)
     {


### PR DESCRIPTION
Analyze_PerformESP was failing because the PlatoESP performer left a signal uncaught.  