### PR TITLE
Fixed a fixed block/sideset/nodeset bug I found when running the SD t…

### DIFF
--- a/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
@@ -1066,10 +1066,13 @@ void append_fixed_blocks_identification_numbers_to_operation
 (const XMLGen::InputData& aXMLMetaData,
  pugi::xml_node& aParentNode)
 {
-    for(auto& tID : aXMLMetaData.optimization_parameters().fixed_block_ids())
+    if(aXMLMetaData.optimization_parameters().fixed_block_ids().size() > 0)
     {
         auto tFixedBlocks = aParentNode.append_child("FixedBlocks");
-        XMLGen::append_children({"Index"}, {tID}, tFixedBlocks);
+        for(auto& tID : aXMLMetaData.optimization_parameters().fixed_block_ids())
+        {
+            XMLGen::append_children({"Index"}, {tID}, tFixedBlocks);
+        }
     }
 }
 // function append_fixed_blocks_identification_numbers_to_operation
@@ -1080,10 +1083,13 @@ void append_fixed_sidesets_identification_numbers_to_operation
 (const XMLGen::InputData& aXMLMetaData,
  pugi::xml_node& aParentNode)
 {
-    for(auto& tID : aXMLMetaData.optimization_parameters().fixed_sideset_ids())
+    if(aXMLMetaData.optimization_parameters().fixed_sideset_ids().size() > 0)
     {
         auto tFixedSideSet = aParentNode.append_child("FixedSidesets");
-        XMLGen::append_children({"Index"}, {tID}, tFixedSideSet);
+        for(auto& tID : aXMLMetaData.optimization_parameters().fixed_sideset_ids())
+        {
+            XMLGen::append_children({"Index"}, {tID}, tFixedSideSet);
+        }
     }
 }
 // function append_fixed_sidesets_identification_numbers_to_operation
@@ -1094,10 +1100,13 @@ void append_fixed_nodesets_identification_numbers_to_operation
 (const XMLGen::InputData& aXMLMetaData,
  pugi::xml_node& aParentNode)
 {
-    for(auto& tID : aXMLMetaData.optimization_parameters().fixed_nodeset_ids())
+    if(aXMLMetaData.optimization_parameters().fixed_nodeset_ids().size() > 0)
     {
         auto tFixedNodeSet = aParentNode.append_child("FixedNodesets");
-        XMLGen::append_children({"Index"}, {tID}, tFixedNodeSet);
+        for(auto& tID : aXMLMetaData.optimization_parameters().fixed_nodeset_ids())
+        {
+            XMLGen::append_children({"Index"}, {tID}, tFixedNodeSet);
+        }
     }
 }
 // function append_fixed_nodesets_identification_numbers_to_operation

--- a/base/src/input_generator/unittest/XMLGeneratorPlatoMainOperationFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorPlatoMainOperationFile_UnitTester.cpp
@@ -68,14 +68,13 @@ TEST(PlatoTestXMLGenerator, AppendSetLowerBoundsToPlatoMainOperation)
     auto tFixedBlocks = tOperation.child("FixedBlocks");
     ASSERT_FALSE(tFixedBlocks.empty());
     ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    tKeys = {"Index"}; tValues = {"1"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedBlocks);
+    auto tIndexNode = tFixedBlocks.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "1");
 
-    tFixedBlocks = tFixedBlocks.next_sibling("FixedBlocks");
-    ASSERT_FALSE(tFixedBlocks.empty());
-    ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    tKeys = {"Index"}; tValues = {"2"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedBlocks);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "2");
 }
 
 TEST(PlatoTestXMLGenerator, AppendSetUpperBoundsToPlatoMainOperation)
@@ -115,26 +114,24 @@ TEST(PlatoTestXMLGenerator, AppendSetUpperBoundsToPlatoMainOperation)
     auto tFixedBlocks = tOperation.child("FixedBlocks");
     ASSERT_FALSE(tFixedBlocks.empty());
     ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    tKeys = {"Index"}; tValues = {"1"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedBlocks);
+    auto tIndexNode = tFixedBlocks.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "1");
 
-    tFixedBlocks = tFixedBlocks.next_sibling("FixedBlocks");
-    ASSERT_FALSE(tFixedBlocks.empty());
-    ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    tKeys = {"Index"}; tValues = {"2"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedBlocks);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "2");
 
     auto tFixedSidesets = tOperation.child("FixedSidesets");
     ASSERT_FALSE(tFixedSidesets.empty());
     ASSERT_STREQ("FixedSidesets", tFixedSidesets.name());
-    tKeys = {"Index"}; tValues = {"11"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedSidesets);
+    tIndexNode = tFixedSidesets.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "11");
 
-    tFixedSidesets = tFixedSidesets.next_sibling("FixedSidesets");
-    ASSERT_FALSE(tFixedSidesets.empty());
-    ASSERT_STREQ("FixedSidesets", tFixedSidesets.name());
-    tKeys = {"Index"}; tValues = {"12"};
-    PlatoTestXMLGenerator::test_children(tKeys, tValues, tFixedSidesets);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "12");
 }
 
 TEST(PlatoTestXMLGenerator, AppendFixedBlocksIdentificationNumbersToOperation_NoFixedBlocks)
@@ -162,12 +159,13 @@ TEST(PlatoTestXMLGenerator, AppendFixedBlocksIdentificationNumbersToOperation)
     auto tFixedBlocks = tDocument.child("FixedBlocks");
     ASSERT_FALSE(tFixedBlocks.empty());
     ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"1"}, tFixedBlocks);
+    auto tIndexNode = tFixedBlocks.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "1");
 
-    tFixedBlocks = tFixedBlocks.next_sibling("FixedBlocks");
-    ASSERT_FALSE(tFixedBlocks.empty());
-    ASSERT_STREQ("FixedBlocks", tFixedBlocks.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"2"}, tFixedBlocks);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "2");
 }
 
 TEST(PlatoTestXMLGenerator, AppendFixedSidesetsIdentificationNumbersToOperation_NoFixedSidesets)
@@ -195,12 +193,13 @@ TEST(PlatoTestXMLGenerator, AppendFixedSidesetsIdentificationNumbersToOperation)
     auto tFixedSideSets = tDocument.child("FixedSidesets");
     ASSERT_FALSE(tFixedSideSets.empty());
     ASSERT_STREQ("FixedSidesets", tFixedSideSets.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"1"}, tFixedSideSets);
+    auto tIndexNode = tFixedSideSets.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "1");
 
-    tFixedSideSets = tFixedSideSets.next_sibling("FixedSidesets");
-    ASSERT_FALSE(tFixedSideSets.empty());
-    ASSERT_STREQ("FixedSidesets", tFixedSideSets.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"2"}, tFixedSideSets);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "2");
 }
 
 TEST(PlatoTestXMLGenerator, AppendFixedNodesetsIdentificationNumbersToOperation_NoFixedNodesets)
@@ -228,12 +227,13 @@ TEST(PlatoTestXMLGenerator, AppendFixedNodesetsIdentificationNumbersToOperation)
     auto tFixedNodesets = tDocument.child("FixedNodesets");
     ASSERT_FALSE(tFixedNodesets.empty());
     ASSERT_STREQ("FixedNodesets", tFixedNodesets.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"1"}, tFixedNodesets);
+    auto tIndexNode = tFixedNodesets.child("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "1");
 
-    tFixedNodesets = tFixedNodesets.next_sibling("FixedNodesets");
-    ASSERT_FALSE(tFixedNodesets.empty());
-    ASSERT_STREQ("FixedNodesets", tFixedNodesets.name());
-    PlatoTestXMLGenerator::test_children({"Index"}, {"2"}, tFixedNodesets);
+    tIndexNode = tIndexNode.next_sibling("Index");
+    ASSERT_FALSE(tIndexNode.empty());
+    ASSERT_STREQ(tIndexNode.child_value(), "2");
 }
 
 TEST(PlatoTestXMLGenerator, AppendComputeVolumeGradientToPlatoMainOperation)


### PR DESCRIPTION
…ests. We weren't writing the data out correctly when there was more than one fixed block.