### PR TITLE
Adding pressure as a load option for PA. It was already supported for…

### DIFF
--- a/base/src/input_generator/XMLGeneratorAnalyzeNaturalBCFunctionInterface.cpp
+++ b/base/src/input_generator/XMLGeneratorAnalyzeNaturalBCFunctionInterface.cpp
@@ -86,7 +86,7 @@ void AppendNaturalBoundaryCondition::insert()
 
     // uniform pressure load
     tFuncIndex = std::type_index(typeid(XMLGen::Private::append_uniform_single_valued_load_to_plato_problem));
-    mMap.insert(std::make_pair("uniform_pressure",
+    mMap.insert(std::make_pair("pressure",
       std::make_pair((XMLGen::Analyze::NaturalBCFunc)XMLGen::Private::append_uniform_single_valued_load_to_plato_problem, tFuncIndex)));
 
     // uniform surface potential

--- a/base/src/input_generator/XMLGeneratorAnalyzeNaturalBCTagFunctionInterface.cpp
+++ b/base/src/input_generator/XMLGeneratorAnalyzeNaturalBCTagFunctionInterface.cpp
@@ -95,7 +95,7 @@ void NaturalBoundaryConditionTag::insert()
 
     // uniform pressure load
     tFuncIndex = std::type_index(typeid(XMLGen::Private::return_pressure_load_name));
-    mMap.insert(std::make_pair("uniform_pressure",
+    mMap.insert(std::make_pair("pressure",
       std::make_pair((XMLGen::Analyze::NaturalBCTagFunc)XMLGen::Private::return_pressure_load_name, tFuncIndex)));
 
     // uniform surface potential

--- a/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
+++ b/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
@@ -826,7 +826,8 @@ struct ValidPhysicsNBCCombinations
     {
         {"steady_state_mechanics", 
             {
-                {"traction", "Natural Boundary Conditions"}
+                {"traction", "Natural Boundary Conditions"},
+                {"pressure", "Natural Boundary Conditions"}
             }
         },
         {"steady_state_thermal", 
@@ -837,12 +838,14 @@ struct ValidPhysicsNBCCombinations
         { "steady_state_thermomechanics", 
             {
                 {"uniform_surface_flux", "Thermal Natural Boundary Conditions"},
-                {"traction", "Mechanical Natural Boundary Conditions"} 
+                {"traction", "Mechanical Natural Boundary Conditions"}, 
+                {"pressure", "Mechanical Natural Boundary Conditions"} 
             }
         },
         {"transient_mechanics", 
             {
-                {"traction", "Natural Boundary Conditions"}
+                {"traction", "Natural Boundary Conditions"},
+                {"pressure", "Natural Boundary Conditions"}
             }
         }
     };

--- a/base/src/input_generator/unittest/XMLGeneratorPlatoAnalyzeInputFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorPlatoAnalyzeInputFile_UnitTester.cpp
@@ -1144,6 +1144,55 @@ TEST(PlatoTestXMLGenerator, AppendNaturalBoundaryConditionsToPlatoAnalyzeInputDe
     }
 }
 
+TEST(PlatoTestXMLGenerator, AppendNaturalBoundaryConditionsToPlatoAnalyzeInputDeck_pressure)
+{
+    XMLGen::InputData tXMLMetaData;
+
+    tXMLMetaData.objective.scenarioIDs.push_back("1");
+
+    XMLGen::NaturalBoundaryCondition tLoad;
+    tLoad.type("pressure");
+    tLoad.id("1");
+    tLoad.location_name("ss_1");
+    std::vector<std::string> tValues = {"1.0"};
+    tLoad.load_values(tValues);
+    tXMLMetaData.loads.push_back(tLoad);
+
+    XMLGen::Scenario tScenario;
+    tScenario.id("1");
+    tScenario.physics("steady_state_mechanics");
+    std::vector<std::string> tLoadIDs = {"1"};
+    tScenario.setLoadIDs(tLoadIDs);
+    tXMLMetaData.append(tScenario);
+
+    pugi::xml_document tDocument;
+    XMLGen::append_natural_boundary_conditions_to_plato_analyze_input_deck(tXMLMetaData, tDocument);
+
+    auto tLoadParamList = tDocument.child("ParameterList");
+    ASSERT_FALSE(tLoadParamList.empty());
+    ASSERT_STREQ("ParameterList", tLoadParamList.name());
+    PlatoTestXMLGenerator::test_attributes({"name"}, {"Natural Boundary Conditions"}, tLoadParamList);
+
+    auto tTraction = tLoadParamList.child("ParameterList");
+    ASSERT_FALSE(tTraction.empty());
+    ASSERT_STREQ("ParameterList", tTraction.name());
+    PlatoTestXMLGenerator::test_attributes({"name"}, {"Uniform Pressure Boundary Condition with ID 1"}, tTraction);
+
+    std::vector<std::string> tGoldKeys = {"name", "type", "value"};
+    std::vector<std::vector<std::string>> tGoldValues =
+        { {"Type", "string", "Uniform"}, {"Values", "Array(double)", "{1.0}"}, {"Sides", "string", "ss_1"} };
+    auto tGoldValuesItr = tGoldValues.begin();
+    auto tParameter = tLoadParamList.child("Parameter");
+    while(!tParameter.empty())
+    {
+        ASSERT_FALSE(tParameter.empty());
+        ASSERT_STREQ("Parameter", tParameter.name());
+        PlatoTestXMLGenerator::test_attributes(tGoldKeys, tGoldValuesItr.operator*(), tParameter);
+        tParameter = tParameter.next_sibling();
+        std::advance(tGoldValuesItr, 1);
+    }
+}
+
 TEST(PlatoTestXMLGenerator, AppendNaturalBoundaryConditionsToPlatoAnalyzeInputDeck_RandomUseCase)
 {
     XMLGen::InputData tXMLMetaData;
@@ -1259,7 +1308,7 @@ TEST(PlatoTestXMLGenerator, AppendNaturalBoundaryCondition_Traction)
 TEST(PlatoTestXMLGenerator, AppendNaturalBoundaryCondition_UniformPressure)
 {
     XMLGen::NaturalBoundaryCondition tLoad;
-    tLoad.type("uniform_pressure");
+    tLoad.type("pressure");
     tLoad.id("1");
     tLoad.location_name("ss_1");
     std::vector<std::string> tValues = {"1.0"};
@@ -1377,7 +1426,7 @@ TEST(PlatoTestXMLGenerator, NaturalBoundaryConditionTag)
 
     // PRESSURE TEST
     tLoad.is_random("false");
-    tLoad.type("uniform_pressure");
+    tLoad.type("pressure");
     tName = tInterface.call(tLoad);
     ASSERT_STREQ("Uniform Pressure Boundary Condition with ID 1", tName.c_str());
 


### PR DESCRIPTION
… SD. There were a couple of places where it was already supported under the name "uniform_pressure". I changed this to pressure so that we don't have two ways of specifying it, one for SD and one for PA.