### PR TITLE
Modal esp

### DIFF
--- a/base/src/input_generator/XMLGeneratorAnalyzeUncertaintyLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorAnalyzeUncertaintyLaunchScriptUtilities.cpp
@@ -1,3 +1,4 @@
+#include "XMLGeneratorInterfaceFileUtilities.hpp"
 #include "pugixml.hpp"
 
 #include "XMLGeneratorUtilities.hpp"
@@ -209,6 +210,9 @@ void generate_mpirun_launch_script(const XMLGen::InputData& aInputData)
     if(aInputData.optimization_parameters().optimizationType() == XMLGen::OT_SHAPE)
     {
         XMLGen::append_esp_initialization_line(aInputData, fp);
+        if (do_tet10_conversion(aInputData)) {
+            XMLGen::append_tet10_conversion_operation_line(fp);
+        }
     }
     XMLGen::append_decomp_lines_for_prune_and_refine(aInputData, fp);
     XMLGen::append_prune_and_refine_lines_to_mpirun_launch_script(aInputData, fp);
@@ -308,7 +312,7 @@ void append_esp_mpirun_lines(const XMLGen::InputData& aInputData, int &aNextPerf
     }
 }
 
-void append_esp_initialization_line(const XMLGen::InputData& aInputData, FILE*& aFile)
+void append_esp_initialization_line(const XMLGen::InputData& aInputData, FILE* aFile)
 {
     std::string tEnvString, tSeparationString, tLaunchString, tNumProcsString;
     XMLGen::determine_mpi_env_and_separation_strings(tEnvString, tSeparationString);
@@ -326,6 +330,11 @@ void append_esp_initialization_line(const XMLGen::InputData& aInputData, FILE*& 
             aInputData.optimization_parameters().csm_exodus_file().c_str(),
             aInputData.optimization_parameters().csm_tesselation_file().c_str());
     }
+}
+
+void append_tet10_conversion_operation_line(FILE* aFile)
+{
+    fprintf(aFile, "cubit -input toTet10.jou -batch -nographics -nogui -noecho -nojournal -nobanner -information off\n");
 }
 
 }

--- a/base/src/input_generator/XMLGeneratorAnalyzeUncertaintyLaunchScriptUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorAnalyzeUncertaintyLaunchScriptUtilities.hpp
@@ -6,7 +6,8 @@
 
 namespace XMLGen
 {
-    void append_esp_initialization_line(const XMLGen::InputData& aInputData, FILE*& aFile);
+    void append_esp_initialization_line(const XMLGen::InputData& aInputData, FILE* aFile);
+    void append_tet10_conversion_operation_line(FILE* aFile);
     void append_esp_mpirun_lines(const XMLGen::InputData& aInputData, int &aNextPerformerID, FILE*& aFile);
     void generate_launch_script(const XMLGen::InputData& aInputData);
     void generate_summit_launch_scripts(const XMLGen::InputData& aInputData);

--- a/base/src/input_generator/XMLGeneratorCriterionMetadata.hpp
+++ b/base/src/input_generator/XMLGeneratorCriterionMetadata.hpp
@@ -29,6 +29,7 @@ private:
     std::vector<std::string> mCriterionWeights;
     std::vector<std::string> mCriterionIDs;
     std::vector<std::string> mModesToExclude;
+    std::vector<std::string> mMatchNodesetIDs;
 
 public:
     /******************************************************************************//**
@@ -377,6 +378,43 @@ public:
     {
         return this->mModesToExclude;
     }
+
+    /******************************************************************************//**
+     * \fn shapeSideset
+     * \brief Set string value for Sierra/SD shape sideset
+     * \param [in] aInput string value
+    **********************************************************************************/
+    void shapeSideset(const std::string& aInput) {
+        this->append("shape_sideset", aInput);
+    }
+
+    /******************************************************************************//**
+     * \fn weightMassScaleFactor
+     * \brief Return string value Sierra/SD shape sideset
+     * \return value
+    **********************************************************************************/
+    std::string shapeSideset() const {
+        return (this->value("shape_sideset"));
+    }
+
+    std::string ref_data_file() const {
+        return this->value("ref_data_file");
+    }
+
+    /******************************************************************************//**
+     * \fn matchNodesetIDs
+     * \brief Return nodeset ids for matching frfs or eigen
+     * \return mMatchNodesetIDs
+    **********************************************************************************/
+    std::vector<std::string> matchNodesetIDs() const {return mMatchNodesetIDs;};
+
+    /******************************************************************************//**
+     * \fn setMatchNodesetIDs
+     * \brief Set nodeset ids for matching frfs or eigen
+     * \param [in] input nodeset IDs 
+    **********************************************************************************/
+    void setMatchNodesetIDs(std::vector<std::string>& aNodesetIDs) {mMatchNodesetIDs = aNodesetIDs;};
+
 
     /* These are all related to stress-constrained mass minimization problems with Sierra/SD */
     std::string volume_misfit_target() const { return this->value("volume_misfit_target"); }

--- a/base/src/input_generator/XMLGeneratorCriterionMetadata.hpp
+++ b/base/src/input_generator/XMLGeneratorCriterionMetadata.hpp
@@ -28,6 +28,7 @@ private:
     std::unordered_map<std::string, std::vector<std::string> > mMetaData; /*!< Scenario metadata, map< tag, vector<values> > */
     std::vector<std::string> mCriterionWeights;
     std::vector<std::string> mCriterionIDs;
+    std::vector<std::string> mModesToExclude;
 
 public:
     /******************************************************************************//**
@@ -357,6 +358,26 @@ public:
         return this->mCriterionWeights;
     }
 
+    /******************************************************************************//**
+     * \fn modesToExclude
+     * \brief Set list of modes to be excluded by modal inverse
+     * \param [in] aInput list of IDs
+     **********************************************************************************/
+    void modesToExclude(const std::vector<std::string>& aInput)
+    {
+        this->mModesToExclude = aInput;
+    }
+
+    /******************************************************************************//**
+     * \fn modesToExclude
+     * \brief Return list of modes to be excluded by modal inverse
+     * \return value
+     **********************************************************************************/
+    std::vector<std::string> modesToExclude() const
+    {
+        return this->mModesToExclude;
+    }
+
     /* These are all related to stress-constrained mass minimization problems with Sierra/SD */
     std::string volume_misfit_target() const { return this->value("volume_misfit_target"); }
     std::string scmm_constraint_exponent() const { return this->value("scmm_constraint_exponent"); }
@@ -381,6 +402,12 @@ public:
     std::string volume_penalty_bias() const { return this->value("volume_penalty_bias"); }
     std::string surface_area_sideset_id() const { return this->value("surface_area_sideset_id"); }
 
+    // Sierra/SD modal objectives
+    std::string num_modes_compute() const { return this->value("num_modes_compute"); }
+    std::vector<std::string> modes_to_exclude() const { return mModesToExclude; }
+    std::string eigen_solver_shift() const { return this->value("eigen_solver_shift"); }
+    std::string camp_solver_tol() const { return this->value("camp_solver_tol"); }
+    std::string camp_max_iter() const { return this->value("camp_max_iter"); }
 };
 // struct Criterion
 

--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
@@ -2244,6 +2244,9 @@ void append_reinitialize_on_change_operation
 (const std::string &aPerformer, 
  pugi::xml_node& aParentNode)
 {
+    if (aPerformer.find("sierra_sd") != std::string::npos) {
+        return;
+    }
     auto tOperationNode = aParentNode.append_child("Operation");
     XMLGen::append_children({"Name", "PerformerName"}, {"Reinitialize on Change", aPerformer}, tOperationNode);
     auto tInputNode = tOperationNode.append_child("Input");

--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
@@ -361,8 +361,12 @@ void append_cache_state_stage
         {
             tParentNode = tStageNode.append_child("Operation");
         }
-        for (auto &tService : aXMLMetaData.services())
+        for(size_t w=0; w<aXMLMetaData.objective.serviceIDs.size(); ++w)
         {
+            auto tServiceID = aXMLMetaData.objective.serviceIDs[w];
+            auto tCriterionID = aXMLMetaData.objective.criteriaIDs[w];
+            auto tCriterion = aXMLMetaData.criterion(tCriterionID);
+            auto tService = aXMLMetaData.service(tServiceID);
             if (!tService.cacheState())
             {
                 continue;
@@ -371,37 +375,41 @@ void append_cache_state_stage
             std::vector<std::string> tKeys = { "Name", "PerformerName" };
             std::vector<std::string> tValues = { "Cache State", tService.performer() };
             XMLGen::append_children(tKeys, tValues, tOperationNode);
-            for(auto &tOutput : aXMLMetaData.mOutputMetaData)
+            if(tCriterion.type() != "modal_projection_error" &&
+               tCriterion.type() != "modal_matching")
             {
-                auto tOutputService = tOutput.serviceID();
-                if(tOutputService == tService.id())
+                for(auto &tOutput : aXMLMetaData.mOutputMetaData)
                 {
-                    if(aXMLMetaData.objective.multi_load_case == "true")
+                    auto tOutputService = tOutput.serviceID();
+                    if(tOutputService == tService.id())
                     {
-                        for(size_t i=0; i<aXMLMetaData.objective.scenarioIDs.size(); ++i)
+                        if(aXMLMetaData.objective.multi_load_case == "true")
                         {
-                            auto tScenarioIndex = std::to_string(i);
+                            for(size_t i=0; i<aXMLMetaData.objective.scenarioIDs.size(); ++i)
+                            {
+                                auto tScenarioIndex = std::to_string(i);
+                                tKeys = {"ArgumentName", "SharedDataName"};
+                                for(auto &tCurData : tOutput.deterministicIDs())
+                                {
+                                    auto tOutputNode = tOperationNode.append_child("Output");
+                                    tValues = {tCurData + tScenarioIndex, tCurData + "_" + tService.performer() +
+                                                  "_scenario_" + aXMLMetaData.objective.scenarioIDs[i]};
+                                    XMLGen::append_children(tKeys, tValues, tOutputNode);
+                                }
+                            }                        
+                        }
+                        else
+                        {
                             tKeys = {"ArgumentName", "SharedDataName"};
                             for(auto &tCurData : tOutput.deterministicIDs())
                             {
                                 auto tOutputNode = tOperationNode.append_child("Output");
-                                tValues = {tCurData + tScenarioIndex, tCurData + "_" + tService.performer() +
-                                              "_scenario_" + aXMLMetaData.objective.scenarioIDs[i]};
+                                tValues = {tCurData + "0", tCurData + "_" + tService.performer()};
                                 XMLGen::append_children(tKeys, tValues, tOutputNode);
                             }
-                        }                        
-                    }
-                    else
-                    {
-                        tKeys = {"ArgumentName", "SharedDataName"};
-                        for(auto &tCurData : tOutput.deterministicIDs())
-                        {
-                            auto tOutputNode = tOperationNode.append_child("Output");
-                            tValues = {tCurData + "0", tCurData + "_" + tService.performer()};
-                            XMLGen::append_children(tKeys, tValues, tOutputNode);
                         }
+                        break;
                     }
-                    break;
                 }
             }
         }
@@ -865,6 +873,23 @@ std::string get_compound_scenario_id(const std::vector<std::string> &aScenarioID
 }
 /******************************************************************************/
 
+int count_number_of_reinitializations_needed
+(const XMLGen::InputData& aXMLMetaData,
+ const XMLGen::Objective& aObjective)
+{
+    int tReturn = 0;
+    for (size_t i=0; i<aObjective.serviceIDs.size(); ++i)
+    {
+        std::string tServiceID = aObjective.serviceIDs[i];
+        XMLGen::Service tService = aXMLMetaData.service(tServiceID); 
+        if (tService.performer().find("sierra_sd") == std::string::npos) 
+        {
+            tReturn++;
+        }
+    }
+    return tReturn;
+}
+
 /******************************************************************************/
 void append_objective_value_stage_for_shape_problem
 (const XMLGen::InputData& aXMLMetaData,
@@ -877,14 +902,19 @@ void append_objective_value_stage_for_shape_problem
     auto tStageInputNode = tStageNode.append_child("Input");
     XMLGen::append_children( { "SharedDataName" }, { "Design Parameters" }, tStageInputNode);
     XMLGen::append_update_geometry_on_change_operation(tFirstPlatoMainPerformer, tStageNode);
-    auto tOuterOperationNode = tStageNode.append_child("Operation");
+    int tNumReinits = count_number_of_reinitializations_needed(aXMLMetaData, tObjective);
+    auto tParentNode = tStageNode;
+    if(tNumReinits > 0)
+    {
+        tParentNode = tStageNode.append_child("Operation");
+    }
     for (size_t i=0; i<tObjective.criteriaIDs.size(); ++i)
     {
         std::string tCriterionID = tObjective.criteriaIDs[i];
         std::string tServiceID = tObjective.serviceIDs[i];
         std::string tScenarioID = tObjective.scenarioIDs[i];
         XMLGen::Service tService = aXMLMetaData.service(tServiceID); 
-        XMLGen::append_reinitialize_on_change_operation(tService.performer(), tOuterOperationNode);
+        XMLGen::append_reinitialize_on_change_operation(tService.performer(), tParentNode);
     }
 
     if(XMLGen::is_robust_optimization_problem(aXMLMetaData))
@@ -1160,14 +1190,19 @@ void append_objective_gradient_stage_for_shape_problem
     auto tStageInputNode = tStageNode.append_child("Input");
     XMLGen::append_children({"SharedDataName"}, {"Design Parameters"}, tStageInputNode);
     XMLGen::append_update_geometry_on_change_operation(tFirstPlatoMainPerformer, tStageNode);
-    auto tOuterOperationNode = tStageNode.append_child("Operation");
+    int tNumReinits = count_number_of_reinitializations_needed(aXMLMetaData, tObjective);
+    auto tParentNode = tStageNode;
+    if(tNumReinits > 0)
+    {
+        tParentNode = tStageNode.append_child("Operation");
+    }
     for (size_t i=0; i<tObjective.criteriaIDs.size(); ++i)
     {
         std::string tCriterionID = tObjective.criteriaIDs[i];
         std::string tServiceID = tObjective.serviceIDs[i];
         std::string tScenarioID = tObjective.scenarioIDs[i];
         XMLGen::Service tService = aXMLMetaData.service(tServiceID); 
-        XMLGen::append_reinitialize_on_change_operation(tService.performer(), tOuterOperationNode);
+        XMLGen::append_reinitialize_on_change_operation(tService.performer(), tParentNode);
     }
 
     if(XMLGen::is_robust_optimization_problem(aXMLMetaData))
@@ -1178,7 +1213,7 @@ void append_objective_gradient_stage_for_shape_problem
     }
     else
     {
-        tOuterOperationNode = tStageNode.append_child("Operation");
+        auto tOuterOperationNode = tStageNode.append_child("Operation");
         XMLGen::append_objective_gradient_operation(aXMLMetaData, tOuterOperationNode);
         append_compute_shape_sensitivity_on_change_operation(tOuterOperationNode);
         tOuterOperationNode = tStageNode.append_child("Operation");
@@ -2399,13 +2434,26 @@ void append_compute_objective_sensitivity_operation
  pugi::xml_node &aParent)
 {
     auto tOperationNode = aParent.append_child("Operation");
-    XMLGen::append_children({"Name", "PerformerName"}, {"Compute Objective Sensitivity", aPerformer}, tOperationNode);
+    if(aPerformer.find("sierra_sd") != std::string::npos) 
+    {
+        XMLGen::append_children({"Name", "PerformerName"}, {"Compute Objective Gradient wrt CAD Parameters", aPerformer}, tOperationNode);
+    }
+    else {
+        XMLGen::append_children({"Name", "PerformerName"}, {"Compute Objective Sensitivity", aPerformer}, tOperationNode);
+    }
     auto tForNode = tOperationNode.append_child("For");
     XMLGen::append_attributes({"var", "in"}, {"I", "Parameters"}, tForNode);
     auto tInputNode = tForNode.append_child("Input");
     XMLGen::append_children({"ArgumentName", "SharedDataName"}, {"Parameter Sensitivity {I}", "Parameter Sensitivity {I}"}, tInputNode);
     auto tOutputNode = tOperationNode.append_child("Output");
-    XMLGen::append_children({"ArgumentName", "SharedDataName"}, {"Criterion Sensitivity", aSharedDataName}, tOutputNode);
+    if(aPerformer.find("sierra_sd") != std::string::npos) 
+    {
+        XMLGen::append_children({"ArgumentName", "SharedDataName"}, {"Internal Energy Gradient", aSharedDataName}, tOutputNode);
+    }
+    else
+    {
+        XMLGen::append_children({"ArgumentName", "SharedDataName"}, {"Criterion Sensitivity", aSharedDataName}, tOutputNode);
+    }
 }
 /******************************************************************************/
 

--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.hpp
@@ -320,6 +320,23 @@ void append_design_parameters_shared_data
  pugi::xml_document& aDocument);
 
 /******************************************************************************//**
+ * \fn do_tet10_conversion
+ * \brief determine whether we are using tet10 conversion
+ * \param [in]     aXMLMetaData Plato problem input data
+**********************************************************************************/
+bool do_tet10_conversion(const XMLGen::InputData& aXMLMetaData);
+
+/******************************************************************************//**
+ * \fn append_tet10_conversion_operation
+ * \brief Append operation for converting to tet10
+ * \param [in]     aXMLMetaData Plato problem input data
+ * \param [in/out] aParentNode  parent xml node
+**********************************************************************************/
+void append_tet10_conversion_operation
+(const std::string &aFirstPlatoMainPerformer, 
+ pugi::xml_node& aParentNode);
+
+/******************************************************************************//**
  * \fn append_constraint_stage_for_topology_problem
  * \brief Append constaint stage for topology optimization problem
  * \param [in]     aXMLMetaData Plato problem input data

--- a/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
@@ -202,8 +202,8 @@ namespace XMLGen
             {
                 if(hasBeenDecompedForThisNumberOfProcessors[num_procs]++ == 0)
                   XMLGen::append_decomp_line(fp, num_procs, aInputData.mesh.run_name);
-                if(tScenario.value("ref_frf_file").length() > 0)
-                  XMLGen::append_decomp_line(fp, num_procs, tScenario.value("ref_frf_file"));
+                if(tScenario.value("ref_data_file").length() > 0)
+                  XMLGen::append_decomp_line(fp, num_procs, tScenario.value("ref_data_file"));
             }
         }
     }

--- a/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
@@ -1,3 +1,4 @@
+#include "XMLGeneratorCriterionMetadata.hpp"
 #include "pugixml.hpp"
 
 #include "XMLGeneratorUtilities.hpp"
@@ -192,7 +193,7 @@ namespace XMLGen
         XMLGen::Service tService = aInputData.service(aInputData.objective.serviceIDs[i]);
         if(tService.code() != "plato_analyze")
         {
-            XMLGen::Scenario tScenario = aInputData.scenario(aInputData.objective.scenarioIDs[i]);
+            XMLGen::Criterion tCriterion = aInputData.criterion(aInputData.objective.criteriaIDs[i]);
             std::string num_procs = tService.numberProcessors();
     
             XMLGen::assert_is_positive_integer(num_procs);
@@ -202,8 +203,8 @@ namespace XMLGen
             {
                 if(hasBeenDecompedForThisNumberOfProcessors[num_procs]++ == 0)
                   XMLGen::append_decomp_line(fp, num_procs, aInputData.mesh.run_name);
-                if(tScenario.value("ref_data_file").length() > 0)
-                  XMLGen::append_decomp_line(fp, num_procs, tScenario.value("ref_data_file"));
+                if(tCriterion.value("ref_data_file").length() > 0)
+                  XMLGen::append_decomp_line(fp, num_procs, tCriterion.value("ref_data_file"));
             }
         }
     }

--- a/base/src/input_generator/XMLGeneratorParseCriteria.cpp
+++ b/base/src/input_generator/XMLGeneratorParseCriteria.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 
+#include "XMLGeneratorCriterionMetadata.hpp"
 #include "XMLGeneratorParseCriteria.hpp"
 #include "XMLGeneratorValidInputKeys.hpp"
 
@@ -103,6 +104,9 @@ void ParseCriteria::allocate()
     mTags.insert({ "eigen_solver_shift", { { {"eigen_solver_shift"}, ""}, "-1e6" } });
     mTags.insert({ "camp_solver_tol", { { {"camp_solver_tol"}, ""}, "1e-6" } });
     mTags.insert({ "camp_max_iter", { { {"camp_max_iter"}, ""}, "1000" } });
+    mTags.insert({ "shape_sideset", { { {"shape_sideset"}, ""}, "" } });
+    mTags.insert({ "ref_data_file", { { {"ref_data_file"}, ""}, "" } });
+    mTags.insert({ "match_nodesets", { { {"match_nodesets"}, ""}, "" } });
 }
 
 void ParseCriteria::setModesToExclude(XMLGen::Criterion &aMetadata)
@@ -117,6 +121,21 @@ void ParseCriteria::setModesToExclude(XMLGen::Criterion &aMetadata)
         aMetadata.modesToExclude(tModes);
     }
 }
+
+void ParseCriteria::setMatchNodesetIDs(XMLGen::Criterion &aMetadata)
+{
+    auto tItr = mTags.find("match_nodesets");
+    std::string tValues = tItr->second.first.second;
+    if (tItr != mTags.end() && !tValues.empty())
+    {
+        std::vector<std::string> tNodesetIDs;
+        char tValuesBuffer[10000];
+        strcpy(tValuesBuffer, tValues.c_str());
+        XMLGen::parse_tokens(tValuesBuffer, tNodesetIDs);
+        aMetadata.setMatchNodesetIDs(tNodesetIDs);
+    }
+}
+
 
 void ParseCriteria::setCriterionWeights(XMLGen::Criterion &aMetadata)
 {
@@ -180,6 +199,7 @@ void ParseCriteria::setMetadata(XMLGen::Criterion& aMetadata)
     this->setCriterionIDs(aMetadata);
     this->setCriterionWeights(aMetadata);
     setModesToExclude(aMetadata);
+    setMatchNodesetIDs(aMetadata);
     this->setTags(aMetadata);
 }
 

--- a/base/src/input_generator/XMLGeneratorParseCriteria.cpp
+++ b/base/src/input_generator/XMLGeneratorParseCriteria.cpp
@@ -96,6 +96,26 @@ void ParseCriteria::allocate()
     mTags.insert({ "volume_penalty_divisor", { { {"volume_penalty_divisor"}, ""}, "" } });
     mTags.insert({ "volume_penalty_bias", { { {"volume_penalty_bias"}, ""}, "" } });
     mTags.insert({ "surface_area_sideset_id", { { {"surface_area_sideset_id"}, ""}, "" } });
+
+    // Sierra/SD modal objectives
+    mTags.insert({ "num_modes_compute", { { {"num_modes_compute"}, ""}, "30" } });
+    mTags.insert({ "modes_to_exclude", { { {"modes_to_exclude"}, ""}, "" } });
+    mTags.insert({ "eigen_solver_shift", { { {"eigen_solver_shift"}, ""}, "-1e6" } });
+    mTags.insert({ "camp_solver_tol", { { {"camp_solver_tol"}, ""}, "1e-6" } });
+    mTags.insert({ "camp_max_iter", { { {"camp_max_iter"}, ""}, "1000" } });
+}
+
+void ParseCriteria::setModesToExclude(XMLGen::Criterion &aMetadata)
+{
+    auto tItr = mTags.find("modes_to_exclude");
+    std::string tValues = tItr->second.first.second;
+    if (tItr != mTags.end() && !tValues.empty()) {
+        std::vector<std::string> tModes;
+        char tValuesBuffer[10000];
+        strcpy(tValuesBuffer, tValues.c_str());
+        XMLGen::parse_tokens(tValuesBuffer, tModes);
+        aMetadata.modesToExclude(tModes);
+    }
 }
 
 void ParseCriteria::setCriterionWeights(XMLGen::Criterion &aMetadata)
@@ -159,6 +179,7 @@ void ParseCriteria::setMetadata(XMLGen::Criterion& aMetadata)
     this->setCriterionType(aMetadata);
     this->setCriterionIDs(aMetadata);
     this->setCriterionWeights(aMetadata);
+    setModesToExclude(aMetadata);
     this->setTags(aMetadata);
 }
 

--- a/base/src/input_generator/XMLGeneratorParseCriteria.hpp
+++ b/base/src/input_generator/XMLGeneratorParseCriteria.hpp
@@ -55,6 +55,13 @@ private:
     void setModesToExclude(XMLGen::Criterion& aMetadata);
 
     /******************************************************************************//**
+     * \fn setMatchNodesetIDs
+     * \brief Set nodeset ids to be used when matching frf or modal data
+     * \param [in] aScenario Scenario metadata
+    **********************************************************************************/
+    void setMatchNodesetIDs(XMLGen::Criterion &aMetadata);
+
+    /******************************************************************************//**
      * \fn setMetaData
      * \brief Set XMLGen::Criterion metadata.
      * \param [in/out] aInputFile parsed input metadata

--- a/base/src/input_generator/XMLGeneratorParseCriteria.hpp
+++ b/base/src/input_generator/XMLGeneratorParseCriteria.hpp
@@ -48,6 +48,13 @@ private:
     void setCriterionWeights(XMLGen::Criterion& aMetadata);
 
     /******************************************************************************//**
+     * \fn setModesToExclude
+     * \brief Set 'modes_to_exclude' keyword for modal inverse
+     * \param [in/out] aInputFile parsed input metadata
+    **********************************************************************************/
+    void setModesToExclude(XMLGen::Criterion& aMetadata);
+
+    /******************************************************************************//**
      * \fn setMetaData
      * \brief Set XMLGen::Criterion metadata.
      * \param [in/out] aInputFile parsed input metadata

--- a/base/src/input_generator/XMLGeneratorParseScenario.cpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.cpp
@@ -48,9 +48,9 @@ void ParseScenario::setLoadIDs(XMLGen::Scenario &aMetadata)
     }
 }
 
-void ParseScenario::setFRFMatchNodesetIDs(XMLGen::Scenario &aMetadata)
+void ParseScenario::setMatchNodesetIDs(XMLGen::Scenario &aMetadata)
 {
-    auto tItr = mTags.find("frf_match_nodesets");
+    auto tItr = mTags.find("match_nodesets");
     std::string tValues = tItr->second.first.second;
     if (tItr != mTags.end() && !tValues.empty())
     {
@@ -126,7 +126,7 @@ void ParseScenario::allocate()
 
     mTags.insert({ "loads", { { {"loads"}, ""}, "" } });
     mTags.insert({ "boundary_conditions", { { {"boundary_conditions"}, ""}, "" } });
-    mTags.insert({ "ref_frf_file", { { {"ref_frf_file"}, ""}, "" } });
+    mTags.insert({ "ref_data_file", { { {"ref_data_file"}, ""}, "" } });
     mTags.insert({ "weight_mass_scale_factor", { { {"weight_mass_scale_factor"}, ""}, "" } });
 
     mTags.insert({ "frequency_min", { { {"frequency_min"}, ""}, "" } });
@@ -134,7 +134,7 @@ void ParseScenario::allocate()
     mTags.insert({ "frequency_step", { { {"frequency_step"}, ""}, "" } });
     mTags.insert({ "raleigh_damping_alpha", { { {"raleigh_damping_alpha"}, ""}, "" } });
     mTags.insert({ "raleigh_damping_beta", { { {"raleigh_damping_beta"}, ""}, "" } });
-    mTags.insert({ "frf_match_nodesets", { { {"frf_match_nodesets"}, ""}, "" } });
+    mTags.insert({ "match_nodesets", { { {"match_nodesets"}, ""}, "" } });
     mTags.insert({ "complex_error_measure", { { {"complex_error_measure"}, ""}, "" } });
     mTags.insert({ "convert_to_tet10", { { {"convert_to_tet10"}, ""}, "" } });
 
@@ -232,7 +232,7 @@ void ParseScenario::parse(std::istream &aInputFile)
             this->setTags(tScenario);
             this->setLoadIDs(tScenario);
             this->setBCIDs(tScenario);
-            this->setFRFMatchNodesetIDs(tScenario);
+            this->setMatchNodesetIDs(tScenario);
             tScenario.id(tScenarioBlockID);
             this->checkTags(tScenario);
             mData.push_back(tScenario);

--- a/base/src/input_generator/XMLGeneratorParseScenario.cpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.cpp
@@ -58,7 +58,7 @@ void ParseScenario::setMatchNodesetIDs(XMLGen::Scenario &aMetadata)
         char tValuesBuffer[10000];
         strcpy(tValuesBuffer, tValues.c_str());
         XMLGen::parse_tokens(tValuesBuffer, tNodesetIDs);
-        aMetadata.setFRFMatchNodesetIDs(tNodesetIDs);
+        aMetadata.setMatchNodesetIDs(tNodesetIDs);
     }
 }
 
@@ -138,8 +138,7 @@ void ParseScenario::allocate()
     mTags.insert({ "complex_error_measure", { { {"complex_error_measure"}, ""}, "" } });
     mTags.insert({ "convert_to_tet10", { { {"convert_to_tet10"}, ""}, "" } });
 
-    //frf matching, some of these probably should belong as criterion parameters instead
-    // mTags.insert({ "normalize_objective", { { {"normalize_objective"}, ""}, "" } });
+    mTags.insert({ "shape_sideset", { { {"shape_sideset"}, ""}, "" } });
 }
 
 void ParseScenario::checkSpatialDimensions(XMLGen::Scenario& aScenario)

--- a/base/src/input_generator/XMLGeneratorParseScenario.cpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.cpp
@@ -48,20 +48,6 @@ void ParseScenario::setLoadIDs(XMLGen::Scenario &aMetadata)
     }
 }
 
-void ParseScenario::setMatchNodesetIDs(XMLGen::Scenario &aMetadata)
-{
-    auto tItr = mTags.find("match_nodesets");
-    std::string tValues = tItr->second.first.second;
-    if (tItr != mTags.end() && !tValues.empty())
-    {
-        std::vector<std::string> tNodesetIDs;
-        char tValuesBuffer[10000];
-        strcpy(tValuesBuffer, tValues.c_str());
-        XMLGen::parse_tokens(tValuesBuffer, tNodesetIDs);
-        aMetadata.setMatchNodesetIDs(tNodesetIDs);
-    }
-}
-
 void ParseScenario::setBCIDs(XMLGen::Scenario &aMetadata)
 {
     auto tItr = mTags.find("boundary_conditions");
@@ -126,7 +112,6 @@ void ParseScenario::allocate()
 
     mTags.insert({ "loads", { { {"loads"}, ""}, "" } });
     mTags.insert({ "boundary_conditions", { { {"boundary_conditions"}, ""}, "" } });
-    mTags.insert({ "ref_data_file", { { {"ref_data_file"}, ""}, "" } });
     mTags.insert({ "weight_mass_scale_factor", { { {"weight_mass_scale_factor"}, ""}, "" } });
 
     mTags.insert({ "frequency_min", { { {"frequency_min"}, ""}, "" } });
@@ -134,11 +119,8 @@ void ParseScenario::allocate()
     mTags.insert({ "frequency_step", { { {"frequency_step"}, ""}, "" } });
     mTags.insert({ "raleigh_damping_alpha", { { {"raleigh_damping_alpha"}, ""}, "" } });
     mTags.insert({ "raleigh_damping_beta", { { {"raleigh_damping_beta"}, ""}, "" } });
-    mTags.insert({ "match_nodesets", { { {"match_nodesets"}, ""}, "" } });
     mTags.insert({ "complex_error_measure", { { {"complex_error_measure"}, ""}, "" } });
     mTags.insert({ "convert_to_tet10", { { {"convert_to_tet10"}, ""}, "" } });
-
-    mTags.insert({ "shape_sideset", { { {"shape_sideset"}, ""}, "" } });
 }
 
 void ParseScenario::checkSpatialDimensions(XMLGen::Scenario& aScenario)
@@ -231,7 +213,6 @@ void ParseScenario::parse(std::istream &aInputFile)
             this->setTags(tScenario);
             this->setLoadIDs(tScenario);
             this->setBCIDs(tScenario);
-            this->setMatchNodesetIDs(tScenario);
             tScenario.id(tScenarioBlockID);
             this->checkTags(tScenario);
             mData.push_back(tScenario);

--- a/base/src/input_generator/XMLGeneratorParseScenario.cpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.cpp
@@ -75,7 +75,7 @@ void ParseScenario::setBCIDs(XMLGen::Scenario &aMetadata)
         XMLGen::parse_tokens(tValuesBuffer, tBCIDs);
         aMetadata.setBCIDs(tBCIDs);
     }
-    else
+    else if (aMetadata.physics() != "modal_response")
     {
         THROWERR("Parse Scenario: boundary_conditions are not defined");
     }

--- a/base/src/input_generator/XMLGeneratorParseScenario.hpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.hpp
@@ -47,13 +47,6 @@ private:
     void setLoadIDs(XMLGen::Scenario& aScenario);
 
     /******************************************************************************//**
-     * \fn setMatchNodesetIDs
-     * \brief Set nodeset ids to be used when matching frf or modal data
-     * \param [in] aScenario Scenario metadata
-    **********************************************************************************/
-    void setMatchNodesetIDs(XMLGen::Scenario &aMetadata);
-
-    /******************************************************************************//**
      * \fn setBCIDs
      * \brief Set Scenario boundary condition ids.
      * \param [in] aScenario Scenario metadata

--- a/base/src/input_generator/XMLGeneratorParseScenario.hpp
+++ b/base/src/input_generator/XMLGeneratorParseScenario.hpp
@@ -47,11 +47,11 @@ private:
     void setLoadIDs(XMLGen::Scenario& aScenario);
 
     /******************************************************************************//**
-     * \fn setFRFMatchNodesetIDs
-     * \brief Set nodeset ids to be used when matching frfs.
+     * \fn setMatchNodesetIDs
+     * \brief Set nodeset ids to be used when matching frf or modal data
      * \param [in] aScenario Scenario metadata
     **********************************************************************************/
-    void setFRFMatchNodesetIDs(XMLGen::Scenario &aMetadata);
+    void setMatchNodesetIDs(XMLGen::Scenario &aMetadata);
 
     /******************************************************************************//**
      * \fn setBCIDs

--- a/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.hpp
@@ -270,6 +270,16 @@ void append_initialize_geometry_operation_to_plato_main_operation
  pugi::xml_document& aDocument);
 
 /******************************************************************************//**
+ * \fn append_tet10_conversion_operation_to_plato_main_operation
+ * \brief Append operation for converting to tet10
+ * \param [in]     aXMLMetaData Plato problem input data
+ * \param [in/out] aDocument  pugi::xml_document
+**********************************************************************************/
+void append_tet10_conversion_operation_to_plato_main_operation
+(const XMLGen::InputData& aXMLMetaData,
+ pugi::xml_document& aDocument);
+
+/******************************************************************************//**
  * \fn append_update_geometry_on_change_operation_to_plato_main_operation
  * \brief Append operation for updating csm geometry
  * \param [in]     aXMLMetaData Plato problem input data

--- a/base/src/input_generator/XMLGeneratorScenarioMetadata.cpp
+++ b/base/src/input_generator/XMLGeneratorScenarioMetadata.cpp
@@ -238,16 +238,6 @@ std::string Scenario::weightMassScaleFactor() const
     return (this->getValue("weight_mass_scale_factor"));
 }
 
-void Scenario::shapeSideset(const std::string& aInput)
-{
-    mMetaData["shape_sideset"] = aInput;
-}
-
-std::string Scenario::shapeSideset() const
-{
-    return (this->getValue("shape_sideset"));
-}
-
 void Scenario::pressureScaling(const std::string& aInput)
 {
     mMetaData["pressure_scaling"] = aInput;

--- a/base/src/input_generator/XMLGeneratorScenarioMetadata.cpp
+++ b/base/src/input_generator/XMLGeneratorScenarioMetadata.cpp
@@ -238,6 +238,16 @@ std::string Scenario::weightMassScaleFactor() const
     return (this->getValue("weight_mass_scale_factor"));
 }
 
+void Scenario::shapeSideset(const std::string& aInput)
+{
+    mMetaData["shape_sideset"] = aInput;
+}
+
+std::string Scenario::shapeSideset() const
+{
+    return (this->getValue("shape_sideset"));
+}
+
 void Scenario::pressureScaling(const std::string& aInput)
 {
     mMetaData["pressure_scaling"] = aInput;

--- a/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
+++ b/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
@@ -24,7 +24,7 @@ private:
     std::unordered_map<std::string, std::string> mMetaData; /*!< Scenario metadata, map< tag, value > */
     std::vector<std::string> mLoadIDs;
     std::vector<std::string> mBCIDs;
-    std::vector<std::string> mFRFMatchNodesetIDs;
+    std::vector<std::string> mMatchNodesetIDs;
 
 // private member functions
 private:
@@ -62,18 +62,18 @@ public:
     void setLoadIDs(std::vector<std::string>& aLoadIDs) {mLoadIDs = aLoadIDs;};
 
     /******************************************************************************//**
-     * \fn frfMatchNodesetIDs
-     * \brief Return nodeset ids for matching frfs
-     * \return mFRFMatchNodesetIDs
+     * \fn matchNodesetIDs
+     * \brief Return nodeset ids for matching frfs or eigen
+     * \return mMatchNodesetIDs
     **********************************************************************************/
-    std::vector<std::string> frfMatchNodesetIDs() const {return mFRFMatchNodesetIDs;};
+    std::vector<std::string> matchNodesetIDs() const {return mMatchNodesetIDs;};
 
     /******************************************************************************//**
-     * \fn setFRFMatchNodesetIDs
-     * \brief Set nodeset ids for matching frfs
+     * \fn setMatchNodesetIDs
+     * \brief Set nodeset ids for matching frfs or eigen
      * \param [in] input nodeset IDs 
     **********************************************************************************/
-    void setFRFMatchNodesetIDs(std::vector<std::string>& aNodesetIDs) {mFRFMatchNodesetIDs = aNodesetIDs;};
+    void setMatchNodesetIDs(std::vector<std::string>& aNodesetIDs) {mMatchNodesetIDs = aNodesetIDs;};
 
     /******************************************************************************//**
      * \fn bcIDs
@@ -393,7 +393,7 @@ public:
     std::string raleigh_damping_beta() const {return this->getValue("raleigh_damping_beta"); }
     std::string complex_error_measure() const {return this->getValue("complex_error_measure"); }
     std::string convert_to_tet10() const {return this->getValue("convert_to_tet10"); }
-    std::string ref_frf_file() const {return this->getValue("ref_frf_file"); }
+    std::string ref_data_file() const {return this->getValue("ref_data_file"); }
 
 };
 // struct Scenario

--- a/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
+++ b/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
@@ -24,7 +24,6 @@ private:
     std::unordered_map<std::string, std::string> mMetaData; /*!< Scenario metadata, map< tag, value > */
     std::vector<std::string> mLoadIDs;
     std::vector<std::string> mBCIDs;
-    std::vector<std::string> mMatchNodesetIDs;
 
 // private member functions
 private:
@@ -60,20 +59,6 @@ public:
      * \param [in] input load IDs 
     **********************************************************************************/
     void setLoadIDs(std::vector<std::string>& aLoadIDs) {mLoadIDs = aLoadIDs;};
-
-    /******************************************************************************//**
-     * \fn matchNodesetIDs
-     * \brief Return nodeset ids for matching frfs or eigen
-     * \return mMatchNodesetIDs
-    **********************************************************************************/
-    std::vector<std::string> matchNodesetIDs() const {return mMatchNodesetIDs;};
-
-    /******************************************************************************//**
-     * \fn setMatchNodesetIDs
-     * \brief Set nodeset ids for matching frfs or eigen
-     * \param [in] input nodeset IDs 
-    **********************************************************************************/
-    void setMatchNodesetIDs(std::vector<std::string>& aNodesetIDs) {mMatchNodesetIDs = aNodesetIDs;};
 
     /******************************************************************************//**
      * \fn bcIDs
@@ -359,20 +344,6 @@ public:
     std::string weightMassScaleFactor() const;
 
     /******************************************************************************//**
-     * \fn shapeSideset
-     * \brief Set string value for Sierra/SD shape sideset
-     * \param [in] aInput string value
-    **********************************************************************************/
-    void shapeSideset(const std::string& aInput);
-
-    /******************************************************************************//**
-     * \fn weightMassScaleFactor
-     * \brief Return string value Sierra/SD shape sideset
-     * \return value
-    **********************************************************************************/
-    std::string shapeSideset() const;
-
-    /******************************************************************************//**
      * \fn pressureScaling
      * \brief Set string value for keyword 'pressure_scaling'.
      * \param [in] aInput string value
@@ -407,7 +378,6 @@ public:
     std::string raleigh_damping_beta() const {return this->getValue("raleigh_damping_beta"); }
     std::string complex_error_measure() const {return this->getValue("complex_error_measure"); }
     std::string convert_to_tet10() const {return this->getValue("convert_to_tet10"); }
-    std::string ref_data_file() const {return this->getValue("ref_data_file"); }
 
 };
 // struct Scenario

--- a/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
+++ b/base/src/input_generator/XMLGeneratorScenarioMetadata.hpp
@@ -359,6 +359,20 @@ public:
     std::string weightMassScaleFactor() const;
 
     /******************************************************************************//**
+     * \fn shapeSideset
+     * \brief Set string value for Sierra/SD shape sideset
+     * \param [in] aInput string value
+    **********************************************************************************/
+    void shapeSideset(const std::string& aInput);
+
+    /******************************************************************************//**
+     * \fn weightMassScaleFactor
+     * \brief Return string value Sierra/SD shape sideset
+     * \return value
+    **********************************************************************************/
+    std::string shapeSideset() const;
+
+    /******************************************************************************//**
      * \fn pressureScaling
      * \brief Set string value for keyword 'pressure_scaling'.
      * \param [in] aInput string value

--- a/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
@@ -15,11 +15,19 @@
 namespace XMLGen
 {
 
+bool isModalCriterion(const XMLGen::Criterion &aCriterion) {
+    return aCriterion.type() == "modal_matching" ||
+           aCriterion.type() == "modal_projection_error";
+}
+
+bool isInverseMethodCase(const XMLGen::Criterion &aCriterion) {
+    return aCriterion.type() == "frf_mismatch" || isModalCriterion(aCriterion);
+}
+
 /**************************************************************************/
-void append_solution_block
-(const XMLGen::InputData& aMetaData,
- std::ostream &outfile)
-{
+void append_solution_block(const XMLGen::InputData &aMetaData,
+                           const XMLGen::Criterion &aCriterion,
+                           std::ostream &outfile) {
     outfile << "SOLUTION" << std::endl;
     if(aMetaData.objective.multi_load_case == "true")
     {
@@ -35,24 +43,238 @@ void append_solution_block
         outfile << "  case '" << aMetaData.objective.scenarioIDs[0] << "'" << std::endl;
         outfile << "  topology_optimization" << std::endl;
     }
+    if (isModalCriterion(aCriterion)) {
+        outfile << "  nmodes " << aCriterion.num_modes_compute() << std::endl;
+        outfile << "  modalAdjointSolver = camp" << std::endl;
+        outfile << "  shift " << aCriterion.eigen_solver_shift() << std::endl;
+    }
     outfile << "  solver gdsw" << std::endl;
     outfile << "END" << std::endl;
 }
 /**************************************************************************/
-void append_parameters_block
-(const XMLGen::Scenario &aScenario,
- std::ostream &outfile)
-{
+void append_parameters_block(const XMLGen::Scenario &aScenario,
+                             const XMLGen::Criterion &aCriterion,
+                             std::ostream &outfile) {
     auto tWeightMassScaleFactor = aScenario.weightMassScaleFactor();
-    if(tWeightMassScaleFactor != "")
+    const bool haveWtMass = (tWeightMassScaleFactor != "");
+    const bool writeSwapModes = isModalCriterion(aCriterion);
+
+    if(haveWtMass || writeSwapModes)
     {
         outfile << "PARAMETERS" << std::endl;
-        outfile << "  WTMASS = " << tWeightMassScaleFactor << std::endl;
+        if (haveWtMass) {
+            outfile << "  WTMASS = " << tWeightMassScaleFactor << std::endl;
+        }
+        if (writeSwapModes) {
+            outfile << "  swapModes no" << std::endl;
+        }
         outfile << "END" << std::endl;
     }
 }
+
+void append_camp_block(const XMLGen::Scenario &aScenario, const XMLGen::Criterion &aCriterion, std::ostream &outfile) {
+    if (isModalCriterion(aCriterion)) {
+        outfile << "CAMP" << std::endl;
+        outfile << "  solver_tol " << aCriterion.camp_solver_tol() << std::endl;
+        outfile << "  preconditioner gdsw" << std::endl;
+        outfile << "  max_iter " << aCriterion.camp_max_iter() << std::endl;
+        outfile << "END" << std::endl;
+    }
+}
+
+void writeOptimizationBlock(std::ostream &outfile)
+{
+    outfile << "OPTIMIZATION" << std::endl;
+    outfile << "  optimization_package ROL_lib" << std::endl;
+    outfile << "  ROLmethod linesearch" << std::endl;
+    outfile << "  LSstep Newton-Krylov" << std::endl;
+    outfile << "  LS_curvature_condition null" << std::endl;
+    outfile << "  Max_iter_Krylov 50" << std::endl;
+    outfile << "  Use_FD_hessvec false" << std::endl;
+    outfile << "  Use_inexact_hessvec false" << std::endl;
+    outfile << "END" << std::endl;
+}
+
+void writeDummyFRFFiles(const XMLGen::Scenario &aScenario, std::ostream &outfile) {
+    std::string tTruthTableFile = "dummy_ttable_";
+    tTruthTableFile += aScenario.id();
+    tTruthTableFile += ".txt";
+    std::string tRealDataFile = "dummy_data_";
+    tRealDataFile += aScenario.id();
+    tRealDataFile += ".txt";
+    std::string tImagDataFile = "dummy_data_im_";
+    tImagDataFile += aScenario.id();
+    tImagDataFile += ".txt";
+    // For levelset frf we will be generating the experimental data
+    // files at each iteration corresponding to the new computational
+    // mesh node ids.  Therefore, we will start things off with 3
+    // dummy files that just have generic data in them.
+    outfile << "  data_truth_table " << tTruthTableFile << std::endl;
+    outfile << "  real_data_file " << tRealDataFile << std::endl;
+    outfile << "  imaginary_data_file " << tImagDataFile << std::endl;
+    // Create the 3 generic files.
+    double tFreqMin, tFreqMax, tFreqStep;
+    sscanf(aScenario.frequency_min().c_str(), "%lf", &tFreqMin);
+    sscanf(aScenario.frequency_max().c_str(), "%lf", &tFreqMax);
+    sscanf(aScenario.frequency_step().c_str(), "%lf", &tFreqStep);
+    // This is the formula sierra_sd uses to get the number of frequencies
+    int tNumFreqs = (int)(((tFreqMax - tFreqMin) / tFreqStep) + 0.5) + 1;
+    int tNumMatchNodes = aScenario.matchNodesetIDs().size();
+    FILE *tTmpFP = fopen(tTruthTableFile.c_str(), "w");
+    if (tTmpFP) {
+        fprintf(tTmpFP, "%d\n", tNumMatchNodes);
+        for (int tIndex = 0; tIndex < tNumMatchNodes; ++tIndex) {
+            fprintf(tTmpFP, "%d 1 1 1\n", tIndex + 1);
+        }
+        fclose(tTmpFP);
+    }
+    tTmpFP = fopen(tRealDataFile.c_str(), "w");
+    if (tTmpFP) {
+        fprintf(tTmpFP, "%d %d\n", 3 * tNumMatchNodes, tNumFreqs);
+        for (int tIndex = 0; tIndex < 3 * tNumMatchNodes; ++tIndex) {
+            for (int tIndex2 = 0; tIndex2 < tNumFreqs; ++tIndex2) {
+                fprintf(tTmpFP, "0 ");
+            }
+            fprintf(tTmpFP, "\n");
+        }
+        fclose(tTmpFP);
+    }
+    tTmpFP = fopen(tImagDataFile.c_str(), "w");
+    if (tTmpFP) {
+        fprintf(tTmpFP, "%d %d\n", 3 * tNumMatchNodes, tNumFreqs);
+        for (int tIndex = 0; tIndex < 3 * tNumMatchNodes; ++tIndex) {
+            for (int tIndex2 = 0; tIndex2 < tNumFreqs; ++tIndex2) {
+                fprintf(tTmpFP, "0 ");
+            }
+            fprintf(tTmpFP, "\n");
+        }
+        fclose(tTmpFP);
+    }
+}
+
+void writeFRFInverseBlocks(const XMLGen::InputData &aMetaData,
+                           const XMLGen::Criterion &aCriterion,
+                           const XMLGen::Scenario &aScenario,
+                           std::ostream &outfile)
+{
+    outfile << "INVERSE-PROBLEM" << std::endl;
+    if (aMetaData.optimization_parameters().discretization().compare("levelset") == 0) {
+        writeDummyFRFFiles(aScenario, outfile);
+    } else {
+        outfile << "  data_truth_table ttable.txt" << std::endl;
+        outfile << "  real_data_file data.txt" << std::endl;
+        outfile << "  imaginary_data_file data_im.txt" << std::endl;
+    }
+    outfile << "END" << std::endl;
+
+    writeOptimizationBlock(outfile);
+
+    if (aScenario.raleigh_damping_alpha().length() > 0 && aScenario.raleigh_damping_beta().length() > 0) {
+        outfile << "DAMPING" << std::endl;
+        outfile << "  alpha " << aScenario.raleigh_damping_alpha() << std::endl;
+        outfile << "  beta " << aScenario.raleigh_damping_beta() << std::endl;
+        outfile << "END" << std::endl;
+    }
+    outfile << "FREQUENCY" << std::endl;
+    outfile << "  freq_min " << aScenario.frequency_min() << std::endl;
+    outfile << "  freq_max " << aScenario.frequency_max() << std::endl;
+    outfile << "  freq_step " << aScenario.frequency_step() << std::endl;
+    outfile << "END" << std::endl;
+
+    outfile << "FUNCTION 1" << std::endl;
+    outfile << "  type linear" << std::endl;
+    outfile << "  data 0 1" << std::endl;
+    outfile << "  data 1e6 1" << std::endl;
+    outfile << "END" << std::endl;
+}
+
+void writeDummyModalFiles(const XMLGen::Scenario &aScenario, const XMLGen::Criterion &aCriterion, std::ostream &outfile) {
+    const std::string id = aScenario.id();
+
+    std::string data_truth_table = "dummy_eigen_ttable_";
+    data_truth_table += aScenario.id();
+    data_truth_table += ".txt";
+    std::string data_file = "dummy_eigen_data_";
+    data_file += aScenario.id();
+    data_file += ".txt";
+    std::string modal_data_file = "dummy_modal_data_";
+    modal_data_file += aScenario.id();
+    modal_data_file += ".txt";
+    std::string modal_weight_table = "dummy_modal_weight_";
+    modal_weight_table += aScenario.id();
+    modal_weight_table += ".txt";
+
+    outfile << "  data_truth_table " << data_truth_table << std::endl;
+    outfile << "  data_file " << data_file << std::endl;
+    outfile << "  modal_data_file " << modal_data_file << std::endl;
+    outfile << "  modal_weight_table " << modal_weight_table << std::endl;
+
+    const auto &matchNodes = aScenario.matchNodesetIDs();
+    const int numNodes = matchNodes.size();
+    int numModes;
+    sscanf(aCriterion.num_modes_compute().c_str(), "%d", &numModes);
+
+    // Create the 4 generic files.
+
+    std::ofstream dummy;
+
+    dummy.open(data_truth_table);
+    dummy << numNodes << " 4" << std::endl;
+    for(int i=0;i<numNodes;i++) {
+        dummy << matchNodes[i] << " 1 1 1" << std::endl;
+    }
+    dummy.close();
+
+    dummy.open(data_file);
+    dummy << 3*numNodes << " " << numModes << std::endl;
+    for(int i=0;i<3*numNodes;i++) {
+        for(int j=0;j<numModes;j++) {
+            dummy << "0 ";
+        }
+        dummy << std::endl;
+    }
+    dummy.close();
+
+    dummy.open(modal_data_file);
+    dummy << numModes << std::endl;
+    for(int i=0;i<numNodes;i++) {
+        dummy << "0" << std::endl;
+    }
+    dummy.close();
+
+    dummy.open(modal_weight_table);
+    dummy << numModes << std::endl;
+    for(int i=0;i<numNodes;i++) {
+        dummy << "1" << std::endl;
+    }
+    dummy.close();
+}
+
+void writeModalInverseBlocks(const XMLGen::InputData &aMetaData,
+                             const XMLGen::Criterion &aCriterion,
+                             const XMLGen::Scenario &aScenario,
+                             std::ostream &outfile)
+{
+    outfile << "INVERSE-PROBLEM" << std::endl;
+
+    writeDummyModalFiles(aScenario, aCriterion, outfile);
+
+    outfile << "  shape_sideset " << aScenario.shapeSideset() << std::endl;
+
+    // dummy value doesn't matter because SD just computes the gradient
+    outfile << "  shape_bounds 1.0" << std::endl;
+ 
+    if (aCriterion.type() == "modal_projection_error") {
+        outfile << "  eigen_objective mpe" << std::endl;
+    }
+    outfile << "  design_variable shape" << std::endl;
+    outfile << "END" << std::endl;
+
+    writeOptimizationBlock(outfile);
+}
+
 /**************************************************************************/
-void append_frf_related_blocks
+void append_inverse_problem_blocks
 (const XMLGen::InputData& aMetaData,
  const XMLGen::Criterion &aCriterion,
  const XMLGen::Scenario &aScenario,
@@ -60,106 +282,11 @@ void append_frf_related_blocks
 {
     if(aCriterion.type() == "frf_mismatch")
     {
-        outfile << "INVERSE-PROBLEM" << std::endl;
-        if(aMetaData.optimization_parameters().discretization().compare("levelset") == 0)
-        {
-            std::string tTruthTableFile = "dummy_ttable_";
-            tTruthTableFile += aScenario.id();
-            tTruthTableFile += ".txt";
-            std::string tRealDataFile = "dummy_data_";
-            tRealDataFile += aScenario.id();
-            tRealDataFile += ".txt";
-            std::string tImagDataFile = "dummy_data_im_";
-            tImagDataFile += aScenario.id();
-            tImagDataFile += ".txt";
-            // For levelset frf we will be generating the experimental data
-            // files at each iteration corresponding to the new computational
-            // mesh node ids.  Therefore, we will start things off with 3
-            // dummy files that just have generic data in them.
-            outfile << "  data_truth_table " << tTruthTableFile << std::endl;
-            outfile << "  real_data_file " << tRealDataFile << std::endl;
-            outfile << "  imaginary_data_file " << tImagDataFile << std::endl;
-            // Create the 3 generic files.
-            double tFreqMin, tFreqMax, tFreqStep;
-            sscanf(aScenario.frequency_min().c_str(), "%lf", &tFreqMin);
-            sscanf(aScenario.frequency_max().c_str(), "%lf", &tFreqMax);
-            sscanf(aScenario.frequency_step().c_str(), "%lf", &tFreqStep);
-            // This is the formula sierra_sd uses to get the number of frequencies
-            int tNumFreqs = (int)(((tFreqMax-tFreqMin)/tFreqStep)+0.5) + 1;
-            int tNumMatchNodes = aScenario.matchNodesetIDs().size();
-            FILE *tTmpFP = fopen(tTruthTableFile.c_str(), "w");
-            if(tTmpFP)
-            {
-                fprintf(tTmpFP, "%d\n", tNumMatchNodes);
-                for(int tIndex=0; tIndex<tNumMatchNodes; ++tIndex)
-                {
-                    fprintf(tTmpFP, "%d 1 1 1\n", tIndex+1);
-                }
-                fclose(tTmpFP);
-            }
-            tTmpFP = fopen(tRealDataFile.c_str(), "w");
-            if(tTmpFP)
-            {
-                fprintf(tTmpFP, "%d %d\n", 3*tNumMatchNodes, tNumFreqs);
-                for(int tIndex=0; tIndex<3*tNumMatchNodes; ++tIndex)
-                {
-                    for(int tIndex2=0; tIndex2<tNumFreqs; ++tIndex2)
-                    {
-                        fprintf(tTmpFP, "0 ");
-                    }
-                    fprintf(tTmpFP, "\n");
-                }
-                fclose(tTmpFP);
-            }
-            tTmpFP = fopen(tImagDataFile.c_str(), "w");
-            if(tTmpFP)
-            {
-                fprintf(tTmpFP, "%d %d\n", 3*tNumMatchNodes, tNumFreqs);
-                for(int tIndex=0; tIndex<3*tNumMatchNodes; ++tIndex)
-                {
-                    for(int tIndex2=0; tIndex2<tNumFreqs; ++tIndex2)
-                    {
-                        fprintf(tTmpFP, "0 ");
-                    }
-                    fprintf(tTmpFP, "\n");
-                }
-                fclose(tTmpFP);
-            }
-        }
-        else
-        {
-            outfile << "  data_truth_table ttable.txt" << std::endl;
-            outfile << "  real_data_file data.txt" << std::endl;
-            outfile << "  imaginary_data_file data_im.txt" << std::endl;
-        }
-        outfile << "END" << std::endl;
-        outfile << "OPTIMIZATION" << std::endl;
-        outfile << "  optimization_package ROL_lib" << std::endl;
-        outfile << "  ROLmethod linesearch" << std::endl;
-        outfile << "  LSstep Newton-Krylov" << std::endl;
-        outfile << "  LS_curvature_condition null" << std::endl;
-        outfile << "  Max_iter_Krylov 50" << std::endl;
-        outfile << "  Use_FD_hessvec false" << std::endl;
-        outfile << "  Use_inexact_hessvec false" << std::endl;
-        outfile << "END" << std::endl;
-        if(aScenario.raleigh_damping_alpha().length() > 0 &&
-           aScenario.raleigh_damping_beta().length() > 0)
-        {
-            outfile << "DAMPING" << std::endl;
-            outfile << "  alpha " << aScenario.raleigh_damping_alpha() << std::endl;
-            outfile << "  beta " << aScenario.raleigh_damping_beta() << std::endl;
-            outfile << "END" << std::endl;
-        }
-        outfile << "FREQUENCY" << std::endl;
-        outfile << "  freq_min " << aScenario.frequency_min() << std::endl;
-        outfile << "  freq_max " << aScenario.frequency_max() << std::endl;
-        outfile << "  freq_step " << aScenario.frequency_step() << std::endl;
-        outfile << "END" << std::endl;
-        outfile << "FUNCTION 1" << std::endl;
-        outfile << "  type linear" << std::endl;
-        outfile << "  data 0 1" << std::endl;
-        outfile << "  data 1e6 1" << std::endl;
-        outfile << "END" << std::endl;
+        writeFRFInverseBlocks(aMetaData, aCriterion, aScenario, outfile);
+    }
+    else if (isModalCriterion(aCriterion))
+    {
+        writeModalInverseBlocks(aMetaData, aCriterion, aScenario, outfile);
     }
 }
 /**************************************************************************/
@@ -195,6 +322,9 @@ void append_gdsw_block
             outfile << "  solver_tol = 1e-4" << std::endl;
         }
     }
+    if (isModalCriterion(aCriterion)) {
+        outfile << "  SC_option 0" << std::endl;
+    }
     outfile << "END" << std::endl;
 }
 /**************************************************************************/
@@ -203,7 +333,7 @@ void append_outputs_block
  std::ostream &outfile)
 {
     outfile << "OUTPUTS" << std::endl;
-    if(aCriterion.type() != "frf_mismatch")
+    if(!isInverseMethodCase(aCriterion))
     {
         outfile << "  topology" << std::endl;
     }
@@ -215,7 +345,7 @@ void append_echo_block
  std::ostream &outfile)
 {
     outfile << "ECHO" << std::endl;
-    if(aCriterion.type() != "frf_mismatch")
+    if(!isInverseMethodCase(aCriterion))
     {
         outfile << "  topology" << std::endl;
     }
@@ -251,7 +381,9 @@ void append_material_blocks
         outfile << "  nu = " << tMaterial.property("poissons_ratio") << std::endl;
         if(tMaterial.property("mass_density").empty() == false)
             outfile << "  density = " << tMaterial.property("mass_density") << std::endl;
-        append_penalty_terms_to_material_block(aMetaData, aCriterion, aScenario, outfile);
+        if (!isModalCriterion(aCriterion)) {
+            append_penalty_terms_to_material_block(aMetaData, aCriterion, aScenario, outfile);
+        }
         outfile << "END" << std::endl;
     }
 }
@@ -284,7 +416,12 @@ void append_block_blocks
         }
         else if(tBlock.element_type == "tet10")
         {
-            outfile << "  tet10" << std::endl;
+            if (isInverseMethodCase(aCriterion)) {
+                outfile << "  cutet10" << std::endl;
+            }
+            else {
+                outfile << "  tet10" << std::endl;
+            }
         }
         else if(tBlock.element_type == "rbar")
         {
@@ -440,15 +577,16 @@ void append_stress_parameters
     }
 }
 
-bool isInverseMethodCase(const XMLGen::Criterion &aCriterion) {
-    return aCriterion.type() == "frf_mismatch";
-}
-
 void writeInverseMethodObjective(const std::string &tDiscretization, const XMLGen::Criterion &aCriterion, std::ostream &outfile) {
-    if(tDiscretization == "density")
-        outfile << "  inverse_method_objective = directfrf-plato-density-method" << std::endl;
-    else if(tDiscretization == "levelset")
-        outfile << "  inverse_method_objective = directfrf-plato-levelset-method" << std::endl;
+    if (aCriterion.type() == "frf_mismatch") {
+        if(tDiscretization == "density")
+            outfile << "  inverse_method_objective = directfrf-plato-density-method" << std::endl;
+        else if(tDiscretization == "levelset")
+            outfile << "  inverse_method_objective = directfrf-plato-levelset-method" << std::endl;
+    }
+    else if (isModalCriterion(aCriterion)) {
+        outfile << "  inverse_method_objective = eigen-inverse" << std::endl;
+    }
 }
 
 /**************************************************************************/
@@ -491,17 +629,25 @@ void append_case
             outfile << "  match_nodesets";
             for(auto tNodesetID : aScenario.matchNodesetIDs())
             {
-                outfile << " " << tNodesetID << std::endl;
-    
+                outfile << " " << tNodesetID;
             }
-            outfile << "" << std::endl;
+            outfile << std::endl;
         }
-        if(aScenario.complex_error_measure().length() > 0)
-            outfile << "  complex_error_measure " << aScenario.complex_error_measure() << std::endl;
+        if (aCriterion.modesToExclude().size() > 0) {
+            outfile << "  modes_to_exclude";
+            for(auto tModeID : aCriterion.modesToExclude()) {
+                outfile << " " << tModeID;
+            }
+            outfile << std::endl;
+        }
+
+        if (aCriterion.type() == "frf_mismatch") {
+            if (aScenario.complex_error_measure().length() > 0)
+                outfile << "  complex_error_measure " << aScenario.complex_error_measure() << std::endl;
+        }
 
         if (aScenario.convert_to_tet10().length()>0)
             outfile << " ls_tet_mesh_type " << aScenario.convert_to_tet10() << std::endl;
-
     }
 }
 /**************************************************************************/
@@ -517,6 +663,9 @@ void append_normalization_parameter
     }
     if(aCriterion.type() == "stress_and_mass")
     {
+        tNormalizeObjective = false;
+    }
+    if (isModalCriterion(aCriterion)) {
         tNormalizeObjective = false;
     }
     if(tNormalizeObjective == false)
@@ -736,9 +885,10 @@ void add_input_deck_blocks
         return;
     }
 
-    append_solution_block(aMetaData, outfile);
-    append_parameters_block(tScenario, outfile);
-    append_frf_related_blocks(aMetaData, tCriterion, tScenario, outfile);
+    append_solution_block(aMetaData, tCriterion, outfile);
+    append_parameters_block(tScenario, tCriterion, outfile);
+    append_camp_block(tScenario, tCriterion, outfile);
+    append_inverse_problem_blocks(aMetaData, tCriterion, tScenario, outfile);
     append_gdsw_block(tCriterion, tScenario, outfile);
     append_outputs_block(tCriterion, outfile);
     append_echo_block(tCriterion, outfile);

--- a/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
@@ -414,7 +414,7 @@ void append_block_blocks
         {
             outfile << "  tet4" << std::endl;
         }
-        else if(tBlock.element_type == "tet10")
+        else if(tBlock.element_type == "tet10" || aScenario.convert_to_tet10().length()>0)
         {
             if (isInverseMethodCase(aCriterion)) {
                 outfile << "  cutet10" << std::endl;
@@ -645,9 +645,6 @@ void append_case
             if (aScenario.complex_error_measure().length() > 0)
                 outfile << "  complex_error_measure " << aScenario.complex_error_measure() << std::endl;
         }
-
-        if (aScenario.convert_to_tet10().length()>0)
-            outfile << " ls_tet_mesh_type " << aScenario.convert_to_tet10() << std::endl;
     }
 }
 /**************************************************************************/
@@ -852,10 +849,10 @@ void append_boundary_block
     outfile << "END" << std::endl;
 }
 /**************************************************************************/
-bool extractMetaDataForWritingInputDeck(const XMLGen::InputData &aMetaData,
-                                        XMLGen::Service &tService,
-                                        XMLGen::Scenario &tScenario,
-                                        XMLGen::Criterion &tCriterion)
+bool extractMetaDataForWritingSDInputDeck(const XMLGen::InputData &aMetaData,
+                                          XMLGen::Service &tService,
+                                          XMLGen::Scenario &tScenario,
+                                          XMLGen::Criterion &tCriterion)
 {
     if(aMetaData.objective.serviceIDs.size() > 0)
     {
@@ -881,7 +878,7 @@ void add_input_deck_blocks
     XMLGen::Scenario tScenario;
     XMLGen::Criterion tCriterion;
 
-    if (!extractMetaDataForWritingInputDeck(aMetaData, tService, tScenario, tCriterion)) {
+    if (!extractMetaDataForWritingSDInputDeck(aMetaData, tService, tScenario, tCriterion)) {
         return;
     }
 
@@ -985,7 +982,7 @@ void augment_sierra_sd_input_deck_with_plato_problem_description(const XMLGen::I
     XMLGen::Scenario tScenario;
     XMLGen::Criterion tCriterion;
 
-    if (!extractMetaDataForWritingInputDeck(aXMLMetaData, tService, tScenario, tCriterion)) {
+    if (!extractMetaDataForWritingSDInputDeck(aXMLMetaData, tService, tScenario, tCriterion)) {
         return;
     }
 

--- a/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <sys/stat.h>
 
+#include "XMLGeneratorCriterionMetadata.hpp"
 #include "XMLGeneratorUtilities.hpp"
 #include "XMLGeneratorSierraSDOperationsFileUtilities.hpp"
 
@@ -95,7 +96,7 @@ void writeOptimizationBlock(std::ostream &outfile)
     outfile << "END" << std::endl;
 }
 
-void writeDummyFRFFiles(const XMLGen::Scenario &aScenario, std::ostream &outfile) {
+void writeDummyFRFFiles(const XMLGen::Scenario &aScenario, const XMLGen::Criterion &aCriterion, std::ostream &outfile) {
     std::string tTruthTableFile = "dummy_ttable_";
     tTruthTableFile += aScenario.id();
     tTruthTableFile += ".txt";
@@ -119,7 +120,7 @@ void writeDummyFRFFiles(const XMLGen::Scenario &aScenario, std::ostream &outfile
     sscanf(aScenario.frequency_step().c_str(), "%lf", &tFreqStep);
     // This is the formula sierra_sd uses to get the number of frequencies
     int tNumFreqs = (int)(((tFreqMax - tFreqMin) / tFreqStep) + 0.5) + 1;
-    int tNumMatchNodes = aScenario.matchNodesetIDs().size();
+    int tNumMatchNodes = aCriterion.matchNodesetIDs().size();
     FILE *tTmpFP = fopen(tTruthTableFile.c_str(), "w");
     if (tTmpFP) {
         fprintf(tTmpFP, "%d\n", tNumMatchNodes);
@@ -159,7 +160,7 @@ void writeFRFInverseBlocks(const XMLGen::InputData &aMetaData,
 {
     outfile << "INVERSE-PROBLEM" << std::endl;
     if (aMetaData.optimization_parameters().discretization().compare("levelset") == 0) {
-        writeDummyFRFFiles(aScenario, outfile);
+        writeDummyFRFFiles(aScenario, aCriterion, outfile);
     } else {
         outfile << "  data_truth_table ttable.txt" << std::endl;
         outfile << "  real_data_file data.txt" << std::endl;
@@ -209,7 +210,7 @@ void writeDummyModalFiles(const XMLGen::Scenario &aScenario, const XMLGen::Crite
     outfile << "  modal_data_file " << modal_data_file << std::endl;
     outfile << "  modal_weight_table " << modal_weight_table << std::endl;
 
-    const auto &matchNodes = aScenario.matchNodesetIDs();
+    const auto &matchNodes = aCriterion.matchNodesetIDs();
     const int numNodes = matchNodes.size();
     int numModes;
     sscanf(aCriterion.num_modes_compute().c_str(), "%d", &numModes);
@@ -259,7 +260,7 @@ void writeModalInverseBlocks(const XMLGen::InputData &aMetaData,
 
     writeDummyModalFiles(aScenario, aCriterion, outfile);
 
-    outfile << "  shape_sideset " << aScenario.shapeSideset() << std::endl;
+    outfile << "  shape_sideset " << aCriterion.shapeSideset() << std::endl;
 
     // dummy value doesn't matter because SD just computes the gradient
     outfile << "  shape_bounds 1.0" << std::endl;
@@ -623,11 +624,11 @@ void append_case
         std::string tDiscretization = aMetaData.optimization_parameters().discretization();
         writeInverseMethodObjective(tDiscretization, aCriterion, outfile);
 
-        outfile << "  ref_data_file " << aScenario.ref_data_file() << std::endl;
-        if(aScenario.matchNodesetIDs().size() > 0)
+        outfile << "  ref_data_file " << aCriterion.ref_data_file() << std::endl;
+        if(aCriterion.matchNodesetIDs().size() > 0)
         {
             outfile << "  match_nodesets";
-            for(auto tNodesetID : aScenario.matchNodesetIDs())
+            for(auto tNodesetID : aCriterion.matchNodesetIDs())
             {
                 outfile << " " << tNodesetID;
             }

--- a/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.cpp
@@ -219,7 +219,7 @@ void writeDummyModalFiles(const XMLGen::Scenario &aScenario, const XMLGen::Crite
     std::ofstream dummy;
 
     dummy.open(data_truth_table);
-    dummy << numNodes << " 4" << std::endl;
+    dummy << numNodes << std::endl;
     for(int i=0;i<numNodes;i++) {
         dummy << matchNodes[i] << " 1 1 1" << std::endl;
     }
@@ -237,14 +237,14 @@ void writeDummyModalFiles(const XMLGen::Scenario &aScenario, const XMLGen::Crite
 
     dummy.open(modal_data_file);
     dummy << numModes << std::endl;
-    for(int i=0;i<numNodes;i++) {
+    for(int i=0;i<numModes;i++) {
         dummy << "0" << std::endl;
     }
     dummy.close();
 
     dummy.open(modal_weight_table);
     dummy << numModes << std::endl;
-    for(int i=0;i<numNodes;i++) {
+    for(int i=0;i<numModes;i++) {
         dummy << "1" << std::endl;
     }
     dummy.close();

--- a/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.hpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDInputDeckUtilities.hpp
@@ -25,5 +25,9 @@ void write_sierra_sd_input_deck
 
 void augment_sierra_sd_input_deck_with_plato_problem_description(const XMLGen::InputData &aXMLMetaData, std::istream &inputDeck, std::ostream &outfile);
 
+bool extractMetaDataForWritingSDInputDeck(const XMLGen::InputData &aMetaData,
+                                          XMLGen::Service &tService,
+                                          XMLGen::Scenario &tScenario,
+                                          XMLGen::Criterion &tCriterion);
 }
 // namespace XMLGen

--- a/base/src/input_generator/XMLGeneratorSierraSDOperationsFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorSierraSDOperationsFileUtilities.cpp
@@ -214,7 +214,9 @@ void add_operations
             append_displacement_operation(tScenario, aDocument);
             append_internal_energy_operation(tScenario, aDocument);
             append_internal_energy_gradient_operation(tScenario, aDocument);
-            append_compute_objective_gradient_operation_for_shape_problem(tScenario, aDocument);
+            if (aMetaData.optimization_parameters().optimizationType() == OT_SHAPE) {
+                append_compute_objective_gradient_operation_for_shape_problem(tScenario, aDocument);
+            }
             append_internal_energy_hessian_operation(aMetaData, tScenario, aDocument);
             append_surface_area_operation(aMetaData, tScenario, aDocument);
             append_surface_area_gradient_operation(aMetaData, tScenario, aDocument);

--- a/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
+++ b/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
@@ -111,7 +111,10 @@ struct ValidCriterionParameterKeys
         "modes_to_exclude",
         "eigen_solver_shift",
         "camp_solver_tol",
-        "camp_max_iter"
+        "camp_max_iter",
+        "shape_sideset",
+        "ref_data_file",
+        "match_nodesets"
     };
 };
 

--- a/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
+++ b/base/src/input_generator/XMLGeneratorValidInputKeys.hpp
@@ -105,7 +105,13 @@ struct ValidCriterionParameterKeys
         "volume_penalty_power",
         "volume_penalty_divisor",
         "volume_penalty_bias",
-        "surface_area_sideset_id"
+        "surface_area_sideset_id",
+        // SD modal objectives
+        "num_modes_compute",
+        "modes_to_exclude",
+        "eigen_solver_shift",
+        "camp_solver_tol",
+        "camp_max_iter"
     };
 };
 
@@ -205,7 +211,9 @@ private:
         "compliance_and_volume_min",
         "surface_pressure",
         "surface_temperature",
-        "flow_rate"
+        "flow_rate",
+        "modal_matching",
+        "modal_projection_error"
     };
 
 public:
@@ -504,6 +512,7 @@ private:
         "plasticity", 
         "thermoplasticity",
         "frequency_response_function",
+        "modal_response",
         "steady_state_incompressible_fluids"
     };
 

--- a/base/src/input_generator/unittest/XMLGeneratorInterfaceFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorInterfaceFile_UnitTester.cpp
@@ -616,8 +616,20 @@ TEST(PlatoTestXMLGenerator, AppendCacheStateStage)
     tService.cacheState("true");
     tMetaData.append(tService);
 
+    XMLGen::Objective tObjective;
+    tObjective.serviceIDs.push_back("1");
+    tObjective.criteriaIDs.push_back("1");
+    tMetaData.objective = tObjective;
+
+    XMLGen::Criterion tCriterion;
+    tCriterion.id("1");
+    tCriterion.type("mass");
+    tMetaData.append(tCriterion);
+
     pugi::xml_document tDocument;
     ASSERT_NO_THROW(XMLGen::append_cache_state_stage(tMetaData, tDocument));
+
+    //tDocument.save_file("xml.txt", " ");
 
     auto tStage = tDocument.child("Stage");
     ASSERT_FALSE(tStage.empty());
@@ -639,13 +651,22 @@ TEST(PlatoTestXMLGenerator, AppendCacheStateStage_multi_load_case)
     tMetaData.append(tService);
     tMetaData.objective.multi_load_case = "true";
     tMetaData.objective.scenarioIDs.push_back("33");
+    tMetaData.objective.serviceIDs.push_back("1");
     XMLGen::Output tOutputMetadata;
     tOutputMetadata.serviceID("1");
     tOutputMetadata.appendDeterminsiticQoI("dispx", "nodal field");
     tMetaData.mOutputMetaData.push_back(tOutputMetadata);
 
+    XMLGen::Criterion tCriterion;
+    tCriterion.id("1");
+    tCriterion.type("mass");
+    tMetaData.append(tCriterion);
+    tMetaData.objective.criteriaIDs.push_back("1");
+
     pugi::xml_document tDocument;
     ASSERT_NO_THROW(XMLGen::append_cache_state_stage(tMetaData, tDocument));
+
+    //tDocument.save_file("xml.txt", " ");
 
     auto tStage = tDocument.child("Stage");
     ASSERT_FALSE(tStage.empty());

--- a/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
@@ -290,10 +290,11 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers)
   tService.numberProcessors("10");
   tInputData.append(tService);
 
-  XMLGen::Scenario tScenario;
-  tScenario.id("1");
-  tScenario.append("ref_data_file", "dummy_frf_file.exo");
-  tInputData.append(tScenario);
+  XMLGen::Criterion tCriterion;
+  tCriterion.id("1");
+  tCriterion.type("frf_mismatch");
+  tCriterion.append("ref_data_file", "dummy_frf_file.exo");
+  tInputData.append(tCriterion);
 
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
@@ -336,10 +337,11 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_noNeedToDecompose)
   tService.numberProcessors("1");
   tInputData.append(tService);
 
-  XMLGen::Scenario tScenario;
-  tScenario.id("1");
-  tScenario.append("ref_data_file", "dummy_frf_file.exo");
-  tInputData.append(tScenario);
+  XMLGen::Criterion tCriterion;
+  tCriterion.id("1");
+  tCriterion.type("frf_mismatch");
+  tCriterion.append("ref_data_file", "dummy_frf_file.exo");
+  tInputData.append(tCriterion);
 
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
@@ -373,15 +375,17 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_multipleObjectivesSam
   tService2.numberProcessors("10");
   tInputData.append(tService2);
 
-  XMLGen::Scenario tScenario;
-  tScenario.id("1");
-  tScenario.append("ref_data_file", "dummy_frf_file.exo");
-  tInputData.append(tScenario);
+  XMLGen::Criterion tCriterion;
+  tCriterion.id("1");
+  tCriterion.type("frf_mismatch");
+  tCriterion.append("ref_data_file", "dummy_frf_file.exo");
+  tInputData.append(tCriterion);
 
-  XMLGen::Scenario tScenario2;
-  tScenario2.id("2");
-  tScenario2.append("ref_data_file", "dummy_frf_file2.exo");
-  tInputData.append(tScenario2);
+  XMLGen::Criterion tCriterion2;
+  tCriterion2.id("2");
+  tCriterion2.type("frf_mismatch");
+  tCriterion2.append("ref_data_file", "dummy_frf_file2.exo");
+  tInputData.append(tCriterion2);
 
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
@@ -412,10 +416,11 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_hasBeenDecomposed)
   tService.numberProcessors("10");
   tInputData.append(tService);
 
-  XMLGen::Scenario tScenario;
-  tScenario.id("1");
-  tScenario.append("ref_data_file", "dummy_frf_file.exo");
-  tInputData.append(tScenario);
+  XMLGen::Criterion tCriterion;
+  tCriterion.id("1");
+  tCriterion.type("frf_mismatch");
+  tCriterion.append("ref_data_file", "dummy_frf_file.exo");
+  tInputData.append(tCriterion);
 
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
@@ -452,10 +457,11 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesToMPILaunchScript)
   tService2.numberProcessors("10");
   tInputData.append(tService2);
 
-  XMLGen::Scenario tScenario;
-  tScenario.id("1");
-  tScenario.append("ref_data_file", "dummy_frf_file.exo");
-  tInputData.append(tScenario);
+  XMLGen::Criterion tCriterion;
+  tCriterion.id("1");
+  tCriterion.type("frf_mismatch");
+  tCriterion.append("ref_data_file", "dummy_frf_file.exo");
+  tInputData.append(tCriterion);
 
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("2");

--- a/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
@@ -292,7 +292,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers)
 
   XMLGen::Scenario tScenario;
   tScenario.id("1");
-  tScenario.append("ref_frf_file", "dummy_frf_file.exo");
+  tScenario.append("ref_data_file", "dummy_frf_file.exo");
   tInputData.append(tScenario);
 
   XMLGen::Objective tObjective;
@@ -338,7 +338,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_noNeedToDecompose)
 
   XMLGen::Scenario tScenario;
   tScenario.id("1");
-  tScenario.append("ref_frf_file", "dummy_frf_file.exo");
+  tScenario.append("ref_data_file", "dummy_frf_file.exo");
   tInputData.append(tScenario);
 
   XMLGen::Objective tObjective;
@@ -375,12 +375,12 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_multipleObjectivesSam
 
   XMLGen::Scenario tScenario;
   tScenario.id("1");
-  tScenario.append("ref_frf_file", "dummy_frf_file.exo");
+  tScenario.append("ref_data_file", "dummy_frf_file.exo");
   tInputData.append(tScenario);
 
   XMLGen::Scenario tScenario2;
   tScenario2.id("2");
-  tScenario2.append("ref_frf_file", "dummy_frf_file2.exo");
+  tScenario2.append("ref_data_file", "dummy_frf_file2.exo");
   tInputData.append(tScenario2);
 
   XMLGen::Objective tObjective;
@@ -414,7 +414,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_hasBeenDecomposed)
 
   XMLGen::Scenario tScenario;
   tScenario.id("1");
-  tScenario.append("ref_frf_file", "dummy_frf_file.exo");
+  tScenario.append("ref_data_file", "dummy_frf_file.exo");
   tInputData.append(tScenario);
 
   XMLGen::Objective tObjective;
@@ -454,7 +454,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesToMPILaunchScript)
 
   XMLGen::Scenario tScenario;
   tScenario.id("1");
-  tScenario.append("ref_frf_file", "dummy_frf_file.exo");
+  tScenario.append("ref_data_file", "dummy_frf_file.exo");
   tInputData.append(tScenario);
 
   XMLGen::Objective tObjective;

--- a/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
@@ -290,6 +290,10 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers)
   tService.numberProcessors("10");
   tInputData.append(tService);
 
+  XMLGen::Scenario tScenario;
+  tScenario.id("1");
+  tInputData.append(tScenario);
+
   XMLGen::Criterion tCriterion;
   tCriterion.id("1");
   tCriterion.type("frf_mismatch");
@@ -299,6 +303,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers)
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
   tObjective.scenarioIDs.push_back("1");
+  tObjective.criteriaIDs.push_back("1");
   tInputData.objective = tObjective;
   FILE* fp=fopen("appendDecompLine.txt", "w");
   std::map<std::string,int> hasBeenDecompedForThisNumberOfProcessors;
@@ -337,6 +342,10 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_noNeedToDecompose)
   tService.numberProcessors("1");
   tInputData.append(tService);
 
+  XMLGen::Scenario tScenario;
+  tScenario.id("1");
+  tInputData.append(tScenario);
+
   XMLGen::Criterion tCriterion;
   tCriterion.id("1");
   tCriterion.type("frf_mismatch");
@@ -346,6 +355,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_noNeedToDecompose)
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
   tObjective.scenarioIDs.push_back("1");
+  tObjective.criteriaIDs.push_back("1");
   tInputData.objective = tObjective;
 
   FILE* fp=fopen("appendDecompLine.txt", "w");
@@ -375,6 +385,10 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_multipleObjectivesSam
   tService2.numberProcessors("10");
   tInputData.append(tService2);
 
+  XMLGen::Scenario tScenario;
+  tScenario.id("1");
+  tInputData.append(tScenario);
+
   XMLGen::Criterion tCriterion;
   tCriterion.id("1");
   tCriterion.type("frf_mismatch");
@@ -392,6 +406,8 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_multipleObjectivesSam
   tObjective.serviceIDs.push_back("2");
   tObjective.scenarioIDs.push_back("1");
   tObjective.scenarioIDs.push_back("2");
+  tObjective.criteriaIDs.push_back("1");
+  tObjective.criteriaIDs.push_back("2");
   tInputData.objective = tObjective;
 
   FILE* fp=fopen("appendDecompLine.txt", "w");
@@ -416,6 +432,10 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_hasBeenDecomposed)
   tService.numberProcessors("10");
   tInputData.append(tService);
 
+  XMLGen::Scenario tScenario;
+  tScenario.id("1");
+  tInputData.append(tScenario);
+
   XMLGen::Criterion tCriterion;
   tCriterion.id("1");
   tCriterion.type("frf_mismatch");
@@ -425,6 +445,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesForPerformers_hasBeenDecomposed)
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("1");
   tObjective.scenarioIDs.push_back("1");
+  tObjective.criteriaIDs.push_back("1");
   tInputData.objective = tObjective;
 
   FILE* fp=fopen("appendDecompLine.txt", "w");
@@ -457,6 +478,10 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesToMPILaunchScript)
   tService2.numberProcessors("10");
   tInputData.append(tService2);
 
+  XMLGen::Scenario tScenario;
+  tScenario.id("1");
+  tInputData.append(tScenario);
+
   XMLGen::Criterion tCriterion;
   tCriterion.id("1");
   tCriterion.type("frf_mismatch");
@@ -466,6 +491,7 @@ TEST(PlatoTestXMLGenerator, appendDecompLinesToMPILaunchScript)
   XMLGen::Objective tObjective;
   tObjective.serviceIDs.push_back("2");
   tObjective.scenarioIDs.push_back("1");
+  tObjective.criteriaIDs.push_back("1");
   tInputData.objective = tObjective;
 
   FILE* fp=fopen("appendDecompLine.txt", "w");

--- a/share/esp/ESPtools.py
+++ b/share/esp/ESPtools.py
@@ -163,13 +163,16 @@ def toExo(meshName, groupAttrs):
   callArgs.append("mark")
   callArgs.append("1")
   callArgs.append("sideset")
-  callArgs.append("surface")
+  callArgs.append("remaining_surface")
 
   for entry in groupAttrs:
     if entry["name"] != "solid_group":
       callArgs.append("mark")
       callArgs.append(entry["index"])
-      callArgs.append("sideset")
+      if entry["name"].find("_nodeset") != -1:
+        callArgs.append("nodeset")
+      else :
+        callArgs.append("sideset")
       callArgs.append(entry["name"])
 
   subprocess.call(callArgs)


### PR DESCRIPTION
In this state, the example we have been using to test SD+ESP is working with the tet10 conversion option; and with shape_sideset, ref_data_file, and match_nodesets moved to the criterion. The XMLGenerator unit tests all pass, and I haven't introduced any new Sierra regression test failures (one already fails on the develop branch).