### PR TITLE
Adds SYSTEM keyword to trilinos includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if( ENABLE_ROL )
   add_definitions(-DENABLE_ROL)
 endif()
 
-include_directories( ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS})
+include_directories(SYSTEM ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS})
 
 
 ###########################  Compiler setup ###################################


### PR DESCRIPTION
this makes it so that warnings in Trilinos are not treated as errors in Plato