### PR TITLE
Simplifying the naming of PlatoMain executable in mpirun.source so th…

### DIFF
--- a/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
@@ -299,6 +299,7 @@ namespace XMLGen
 
   void determine_plato_engine_name(const XMLGen::InputData& aInputData, std::string& aPlatoEngineName)
   {
+/*
       bool tAtLeastOneSierraSDPhysicsPerformer = false;
       bool tAllPhysicsPerformersAreSierraSD = true;
       for(auto &tCurService : aInputData.services())
@@ -329,8 +330,9 @@ namespace XMLGen
      }
      else
      {
+*/
          aPlatoEngineName = "PlatoMain";   
-     }
+ //    }
   }
 
   namespace Internal


### PR DESCRIPTION
…at it is consistent for both SD runs and PA runs.