### PR TITLE
Fix for refining more than one level in prune_and_refine. Something m…

### DIFF
--- a/base/src/prune/main/MeshRefine.cpp
+++ b/base/src/prune/main/MeshRefine.cpp
@@ -5,6 +5,7 @@
  *      Author: tzirkle
  */
 
+#include <cstdio>
 #include "MeshRefine.hpp"
 
     MeshRefine::MeshRefine()
@@ -16,7 +17,12 @@
     {
         PerceptMesh & tPerceptMesh = tMeshManager.get_output_percept();
 
-        tPerceptMesh.reopen();
+        char tTempFilename[100];
+        static int gCntr=0;
+        sprintf(tTempFilename, "tmp_file_name_%d.e", gCntr);
+        gCntr++;
+        tPerceptMesh.reopen(tTempFilename);
+        remove(tTempFilename);
 
         stk::mesh::PartVector parts;
         tPerceptMesh.get_parts_of_rank(tPerceptMesh.element_rank(), parts);


### PR DESCRIPTION
…ust have changed in the way the PerceptMesh was handling file pointers and reopening files that was causing this code that used to work to stop working. The fix was to explicitly specify the temp file name that was being used to write/read from disk. Also, added call to clean up old tmp files so they won't be left in the run directory using up disk space unnecessarily.