### PR TITLE
remotes trilinos_tpl_libraries from link line

### DIFF
--- a/apps/services/CMakeLists.txt
+++ b/apps/services/CMakeLists.txt
@@ -25,7 +25,7 @@ if (PLATO_ENABLE_SERVICES_PYTHON)
     add_library( PlatoServices SHARED PlatoApp.cpp ServicesPythonModule.cpp )
     target_include_directories(PlatoServices SYSTEM PRIVATE ${Python2_INCLUDE_DIRS} )
     target_link_libraries( PlatoServices ${PLATO_LIBRARIES} ${PLATO_LIBRARIES} ${Trilinos_LIBRARIES} 
-                           ${Trilinos_TPL_LIBRARIES} ${Python2_LIBRARIES} )
+                           ${Python2_LIBRARIES} )
     set_target_properties( PlatoServices PROPERTIES PREFIX "" )
     target_compile_options( PlatoServices PRIVATE "-lmpi" )
 

--- a/apps/services/unittest/CMakeLists.txt
+++ b/apps/services/unittest/CMakeLists.txt
@@ -138,7 +138,7 @@ INCLUDE_DIRECTORIES(${PLATOUNIT_INCLUDES})
 # actual target:
 #set(PLATOMAINUNITTESTER_ADDITIONAL_LIBS ${CMAKE_SOURCE_DIR}/tpls/gtest/build) 
 set(PLATOMAINUNITTESTER_LIBS ${PLATOMAINUNITTESTER_ADDITIONAL_LIBS} ${PLATO_LIBRARIES} ${PLATO_LIBRARIES} 
-                             ${NLOPT_LIBRARY} ${GTEST_BOTH_LIBRARIES} ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES} ${PYTHON_LIBRARY} 
+                             ${NLOPT_LIBRARY} ${GTEST_BOTH_LIBRARIES} ${Trilinos_LIBRARIES} ${PYTHON_LIBRARY} 
                              ${PYTHON_LINK_LIBS} ${Plato_EXTRA_LINK_FLAGS})
 add_executable(PlatoMainUnitTester ${PlatoMainUnitTester_SRCS})
 target_link_libraries(PlatoMainUnitTester PlatoApp ${PLATOMAINUNITTESTER_LIBS})


### PR DESCRIPTION
This got rid of error 127. No other issues building so it appears that these targets didn't need those libraries anyway