### PR TITLE
add prefix PERF_ to slow tests

### DIFF
--- a/apps/services/unittest/Plato_Test_KelleySachsBounds.cpp
+++ b/apps/services/unittest/Plato_Test_KelleySachsBounds.cpp
@@ -270,7 +270,7 @@ TEST(PlatoTest, ReducedSpaceTrustRegionStageMngTestTwo)
     }
 }
 
-TEST(PlatoTest, KelleySachsBoundConstrainedTopo)
+TEST(PlatoTest, PERF_KelleySachsBoundConstrainedTopo)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -331,7 +331,7 @@ TEST(PlatoTest, KelleySachsBoundConstrainedTopo)
     }
 }
 
-TEST(PlatoTest, KelleySachsBoundConstrainedTopo_LBFGS)
+TEST(PlatoTest, PERF_KelleySachsBoundConstrainedTopo_LBFGS)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;

--- a/apps/services/unittest/Plato_Test_MethodMovingAsymptotes.cpp
+++ b/apps/services/unittest/Plato_Test_MethodMovingAsymptotes.cpp
@@ -889,7 +889,7 @@ TEST(PlatoTest, MethodMovingAsymptotes_HimmelblauShiftedEllipse_IPOPT)
 }
 #endif
 
-TEST(PlatoTest, MethodMovingAsymptotes_HimmelblauShiftedEllipse_KSAL)
+TEST(PlatoTest, PERF_MethodMovingAsymptotes_HimmelblauShiftedEllipse_KSAL)
 {
     // ********* SET OBJECTIVE AND COSNTRAINT *********
     std::shared_ptr<Plato::Himmelblau<double>> tObjective = std::make_shared<Plato::Himmelblau<double>>();
@@ -1051,7 +1051,7 @@ TEST(PlatoTest, MethodMovingAsymptotes_CircleRadius)
     std::cout << tOutputs.mStopCriterion.c_str() << "\n" << std::flush;
 }
 
-TEST(DISABLED_PlatoTest, MethodMovingAsymptotes_MinComplianceVolumeConstraint)
+TEST(DISABLED_PlatoTest, PERF_MethodMovingAsymptotes_MinComplianceVolumeConstraint)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const int tNumElementsXDir = 30;

--- a/apps/services/unittest/Plato_Test_SimpleRocketOptimization.cpp
+++ b/apps/services/unittest/Plato_Test_SimpleRocketOptimization.cpp
@@ -225,7 +225,7 @@ TEST(PlatoTest, Cylinder)
     EXPECT_NEAR(tArea, 37.699111843077520, tTolerance);
 }
 
-TEST(PlatoTest, GradFreeSimpleRocketOptimization)
+TEST(PlatoTest, PERF_GradFreeSimpleRocketOptimization)
 {
     // define objective
     Plato::AlgebraicRocketInputs<double> tRocketInputs;
@@ -265,7 +265,7 @@ TEST(PlatoTest, GradFreeSimpleRocketOptimization)
     EXPECT_FLOAT_EQ(tBestObjectiveValue, tObjective.evaluate(tBestParameters));
 }
 
-TEST(PlatoTest, GradBasedSimpleRocketOptimizationWithLightInterface)
+TEST(PlatoTest, PERF_GradBasedSimpleRocketOptimizationWithLightInterface)
 {
     // ********* SET NORMALIZATION CONSTANTS *********
     const size_t tNumControls = 2;
@@ -319,7 +319,7 @@ TEST(PlatoTest, GradBasedSimpleRocketOptimizationWithLightInterface)
     std::cout << "StoppingCriterion = " << tOutputs.mStopCriterion.c_str() << std::endl;
 }
 
-TEST(PlatoTest, GradBasedSimpleRocketOptimizationWithLightInterface_LBFGS)
+TEST(PlatoTest, PERF_GradBasedSimpleRocketOptimizationWithLightInterface_LBFGS)
 {
     // ********* SET NORMALIZATION CONSTANTS *********
     const size_t tNumControls = 2;

--- a/apps/services/unittest/Plato_Test_SimpleTopOpt.cpp
+++ b/apps/services/unittest/Plato_Test_SimpleTopOpt.cpp
@@ -462,7 +462,7 @@ TEST(PlatoTest, ProxyVolume)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoOptimalityCriteriaLightInterface)
+TEST(PlatoTest, PERF_SolveStrucTopoOptimalityCriteriaLightInterface)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -522,7 +522,7 @@ TEST(PlatoTest, SolveStrucTopoOptimalityCriteriaLightInterface)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoGloballyConvergentMethodMovingAsymptotesLightInterface)
+TEST(PlatoTest, PERF_SolveStrucTopoGloballyConvergentMethodMovingAsymptotesLightInterface)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -585,7 +585,7 @@ TEST(PlatoTest, SolveStrucTopoGloballyConvergentMethodMovingAsymptotesLightInter
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_1)
+TEST(PlatoTest, PERF_SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_1)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -646,7 +646,7 @@ TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_1)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_2)
+TEST(PlatoTest, PERF_SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_2)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -708,7 +708,7 @@ TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_2)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_3)
+TEST(PlatoTest, PERF_SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_3)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -771,7 +771,7 @@ TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_3)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_4)
+TEST(PlatoTest, PERF_SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_4)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -833,7 +833,7 @@ TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_4)
     }
 }
 
-TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_5)
+TEST(PlatoTest, PERF_SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_5)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;
@@ -894,7 +894,7 @@ TEST(PlatoTest, SolveStrucTopoWithTrustRegionAugmentedLagrangianLight_5)
     }
 }
 
-TEST(PlatoTest, CheckSimpleTopoProxyCriteria)
+TEST(PlatoTest, PERF_CheckSimpleTopoProxyCriteria)
 {
     // ************** ALLOCATE SIMPLE STRUCTURAL TOPOLOGY OPTIMIZATION SOLVER **************
     const double tPoissonRatio = 0.3;

--- a/apps/services/unittest/Plato_Test_Statistics.cpp
+++ b/apps/services/unittest/Plato_Test_Statistics.cpp
@@ -987,7 +987,7 @@ TEST(PlatoTest, BetaCDF2)
     }
 }
 
-TEST(PlatoTest, PlotBetaCDF)
+TEST(PlatoTest, PERF_PlotBetaCDF)
 {
     // BUILD BETA DISTRIBUTION
     const double tMean = 90;
@@ -1466,7 +1466,7 @@ TEST(PlatoTest, CheckSromConstraintGradient)
     }
 }
 
-TEST(PlatoTest, SolveSromProblem_CorrelatedVars_BetaDistribution)
+TEST(PlatoTest, PERF_SolveSromProblem_CorrelatedVars_BetaDistribution)
 {
     // POSE CORRELATION MATRIX
     Plato::io::MetaData tFileMetaData;

--- a/apps/services/unittest/Plato_Test_UncertainLoadGeneratorXML.cpp
+++ b/apps/services/unittest/Plato_Test_UncertainLoadGeneratorXML.cpp
@@ -2258,7 +2258,7 @@ TEST(PlatoTest, generate_load_sroms_error)
     ASSERT_FALSE(Plato::srom::build_load_sroms(tInputs, tOutputs));
 }
 
-TEST(PlatoTest, generate_load_sroms_both_random_and_deterministic_loads)
+TEST(PlatoTest, PERF_generate_load_sroms_both_random_and_deterministic_loads)
 {
     // SET INPUTS - CREATE FIRST RANDOM LOAD
     Plato::srom::Load tLoad1;
@@ -2415,7 +2415,7 @@ TEST(PlatoTest, generate_load_sroms_both_random_and_deterministic_loads)
     Plato::system("rm -f plato_ksal_algorithm_diagnostics.txt");
 }
 
-TEST(PlatoTest, generate_load_sroms_only_random_loads)
+TEST(PlatoTest, PERF_generate_load_sroms_only_random_loads)
 {
     // SET INPUTS - CREATE FIRST RANDOM LOAD
     Plato::srom::Load tLoad1;


### PR DESCRIPTION
Can run only these tests with --gtest_filter=*PERF_* or only the fast
tests with --gtest_filter=-*PERF_*. Non-PERF tests run in less than
two seconds.