### PR TITLE
-Fix so that only one "shape_service" is added to the performer list …

### DIFF
--- a/base/src/input_generator/XMLGenerator.cpp
+++ b/base/src/input_generator/XMLGenerator.cpp
@@ -471,7 +471,17 @@ namespace XMLGen
             aInputData.mPerformerServices.push_back(aInputData.service(tServiceID));
             if (tShapeServiceID != "")
             {
-                aInputData.mPerformerServices.push_back(aInputData.service(tShapeServiceID));
+                bool tFound=false;
+                for(auto &tCurService : aInputData.mPerformerServices)
+                {
+                    if(tCurService.id() == tShapeServiceID)
+                    {
+                        tFound = true; 
+                        break;
+                    }
+                }
+                if(!tFound)
+                    aInputData.mPerformerServices.push_back(aInputData.service(tShapeServiceID));
             }
         }
     }

--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
@@ -1183,25 +1183,17 @@ void append_objective_gradient_operation
 (const XMLGen::InputData& aXMLMetaData,
  pugi::xml_node &aParentNode)
 {
-    pugi::xml_node tParentNode = aParentNode;
     XMLGen::Objective tObjective = aXMLMetaData.objective;
-
     bool tMultiObjective = (tObjective.criteriaIDs.size() > 1 &&
                             tObjective.multi_load_case != "true");
 
-    // If there is more than one sub-objective add an
-    // outer "Operation" block so the sub-objectives
-    // will be executed in parallel.
-    if(tMultiObjective)
-        tParentNode = aParentNode.append_child("Operation");
-
     if(tObjective.multi_load_case == "true")
     {
-        append_objective_gradient_operation_for_multi_load_case(aXMLMetaData, tParentNode);
+        append_objective_gradient_operation_for_multi_load_case(aXMLMetaData, aParentNode);
     }
     else
     {
-        append_objective_gradient_operation_for_non_multi_load_case(aXMLMetaData, tParentNode);
+        append_objective_gradient_operation_for_non_multi_load_case(aXMLMetaData, aParentNode);
     }
 }
 /******************************************************************************/
@@ -1299,7 +1291,19 @@ void append_objective_gradient_stage_for_topology_problem
     }
     else
     {
-        XMLGen::append_objective_gradient_operation(aXMLMetaData, tStageNode);
+        pugi::xml_node tParentNode = tStageNode;
+        XMLGen::Objective tObjective = aXMLMetaData.objective;
+
+        bool tMultiObjective = (tObjective.criteriaIDs.size() > 1 &&
+                                tObjective.multi_load_case != "true");
+
+        // If there is more than one sub-objective add an
+        // outer "Operation" block so the sub-objectives
+        // will be executed in parallel.
+        if(tMultiObjective)
+            tParentNode = tParentNode.append_child("Operation");
+
+        XMLGen::append_objective_gradient_operation(aXMLMetaData, tParentNode);
         if(aXMLMetaData.needToAggregate())
         {
             XMLGen::append_aggregate_objective_gradient_operation(aXMLMetaData, tStageNode);
@@ -2668,7 +2672,7 @@ void append_initialize_geometry_operation
 {
     std::string tFirstPlatoMainPerformer = aXMLMetaData.getFirstPlatoMainPerformer();
     auto tOperationNode = aParentNode.append_child("Operation");
-    XMLGen::append_children({"Name", "PerformerName"},{"Generate XTK Model", tFirstPlatoMainPerformer}, tOperationNode);
+    XMLGen::append_children({"Name", "PerformerName"},{"Initialize Geometry", tFirstPlatoMainPerformer}, tOperationNode);
 }
 // function append_initialize_geometry_operation
 /******************************************************************************/

--- a/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorInterfaceFileUtilities.cpp
@@ -1184,8 +1184,6 @@ void append_objective_gradient_operation
  pugi::xml_node &aParentNode)
 {
     XMLGen::Objective tObjective = aXMLMetaData.objective;
-    bool tMultiObjective = (tObjective.criteriaIDs.size() > 1 &&
-                            tObjective.multi_load_case != "true");
 
     if(tObjective.multi_load_case == "true")
     {

--- a/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
@@ -272,7 +272,7 @@ namespace XMLGen
     XMLGen::assert_is_positive_integer(num_opt_procs);
 
     // Now add the main mpirun call.
-    fprintf(fp, "%s %s %s %s PLATO_PERFORMER_ID%s0 \\\n", tLaunchString.c_str(), 
+    fprintf(fp, "%s --oversubscribe %s %s %s PLATO_PERFORMER_ID%s0 \\\n", tLaunchString.c_str(), 
                                 tNumProcsString.c_str(), num_opt_procs.c_str(),
                                 envString.c_str(),separationString.c_str());
     fprintf(fp, "%s PLATO_INTERFACE_FILE%sinterface.xml \\\n", envString.c_str(),separationString.c_str());

--- a/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
@@ -521,7 +521,7 @@ TEST(PlatoTestXMLGenerator, appendEngineMPIRunLines)
   fclose(fp);
 
   auto tReadData = XMLGen::read_data_from_file("appendEngineMPIRunLines.txt");
-  auto tGold = std::string("mpiexec-np10-xPLATO_PERFORMER_ID=0\\-xPLATO_INTERFACE_FILE=interface.xml\\-xPLATO_APP_FILE=plato_main_operations.xml\\/home/path/to/PlatoMainplato_main_input_deck.xml\\");
+  auto tGold = std::string("mpiexec--oversubscribe-np10-xPLATO_PERFORMER_ID=0\\-xPLATO_INTERFACE_FILE=interface.xml\\-xPLATO_APP_FILE=plato_main_operations.xml\\/home/path/to/PlatoMainplato_main_input_deck.xml\\");
 
   EXPECT_STREQ(tReadData.str().c_str(),tGold.c_str());
   Plato::system("rm -rf appendEngineMPIRunLines.txt");


### PR DESCRIPTION
…when it is referenced multiple times in the input deck

-Fix to avoid doubly nested operations when doing a SO problem with multiple load case performers
-Changed append_initialize_geometry_operation back to where it was. XTK operation was incorrectly added.
-Added --oversubscribe to all mpirun/mpiexec commands