### PR TITLE
only use --oversubscribe with OpenMPI

### DIFF
--- a/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorLaunchScriptUtilities.cpp
@@ -272,7 +272,7 @@ namespace XMLGen
     XMLGen::assert_is_positive_integer(num_opt_procs);
 
     // Now add the main mpirun call.
-    fprintf(fp, "%s --oversubscribe %s %s %s PLATO_PERFORMER_ID%s0 \\\n", tLaunchString.c_str(), 
+    fprintf(fp, "%s %s %s %s PLATO_PERFORMER_ID%s0 \\\n", tLaunchString.c_str(), 
                                 tNumProcsString.c_str(), num_opt_procs.c_str(),
                                 envString.c_str(),separationString.c_str());
     fprintf(fp, "%s PLATO_INTERFACE_FILE%sinterface.xml \\\n", envString.c_str(),separationString.c_str());
@@ -306,6 +306,9 @@ namespace XMLGen
     else
     {
       aLaunchString = "mpiexec";
+#ifdef USING_OPEN_MPI
+      aLaunchString += " --oversubscribe";
+#endif
       aNumProcsString = "-np";
     }
   }

--- a/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorLaunchScript_UnitTester.cpp
@@ -118,7 +118,13 @@ TEST(PlatoTestXMLGenerator, determineMPILaunchStrings_dontUseLaunch)
   std::string tLaunchString, tNumProcsString;
   XMLGen::determine_mpi_launch_strings(tInputData, tLaunchString, tNumProcsString);
 
-  EXPECT_STREQ("mpiexec", tLaunchString.c_str());
+#ifdef USING_OPEN_MPI
+  const std::string goldLaunchString("mpiexec --oversubscribe");
+#else
+  const std::string goldLaunchString("mpiexec");
+#endif
+
+  EXPECT_STREQ(goldLaunchString.c_str(), tLaunchString.c_str());
   EXPECT_STREQ("-np", tNumProcsString.c_str());
 }
 


### PR DESCRIPTION
The --oversubscribe flag is supported by OpenMPI, but not Intel MPI. After merging in develop, a bunch of Sierra tests using the Intel compiler broke. This should fix it.