### PR TITLE
switch from shardes to id command

### DIFF
--- a/base/src/input_generator/Operation.cpp
+++ b/base/src/input_generator/Operation.cpp
@@ -58,7 +58,7 @@ OperationWait::OperationWait
  int aConcurrentEvaluations) :
  Operation(aName, "SystemCall",aPerformer, aConcurrentEvaluations)
 {
-    mCommand = std::string("while lsof -u $USER | grep ./") + aFile + "; do sleep 1; done";
+    mCommand = std::string("while lsof -u `id -u -n` | grep ./") + aFile + "; do sleep 1; done";
     mOnChange = false;    
 }
 

--- a/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
+++ b/base/src/input_generator/XMLGeneratorPlatoMainOperationFileUtilities.cpp
@@ -1072,7 +1072,7 @@ void append_mesh_rename_operation_to_plato_main_operation
         const std::string joinedMeshFile(aXMLMetaData.mesh.joined_mesh_name);
 
         std::stringstream moveCmd;
-        moveCmd << "while lsof -u $USER | grep " << joinedMeshFile << "; do sleep 1; done; ";
+        moveCmd << "while lsof -u `id -u -n` | grep " << joinedMeshFile << "; do sleep 1; done; ";
         moveCmd << "/bin/cp " << joinedMeshFile << " " << exodusFile;
 
         pugi::xml_node operationNode = aDocument.append_child("Operation");
@@ -1150,7 +1150,7 @@ void append_wait_for_file_close_operation_commands
    
     addChild(tNode, "Function", "SystemCall");
     addChild(tNode, "Name", aName);
-    std::string tCommand = "while lsof -u $USER | grep " + aFolder + "/" + aFile + "; do sleep 1; done; ";
+    std::string tCommand = "while lsof -u `id -u -n` | grep " + aFolder + "/" + aFile + "; do sleep 1; done; ";
     addChild(tNode, "Command", tCommand);
     addChild(tNode, "OnChange", "false");
  }

--- a/base/src/input_generator/unittest/Operation_UnitTester.cpp
+++ b/base/src/input_generator/unittest/Operation_UnitTester.cpp
@@ -82,7 +82,7 @@ TEST(OperationTest, WriteDefinitionWaitOperationWithConcurrency)
         "OnChange"};
     std::vector<std::string> tValues = {"SystemCall", 
         "wait_0", 
-        "while lsof -u $USER | grep ./file; do sleep 1; done", 
+        "while lsof -u `id -u -n` | grep ./file; do sleep 1; done", 
         "evaluations_0",
         "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);
@@ -110,7 +110,7 @@ TEST(OperationTest, WriteDefinitionWaitOperationNoConcurrency)
         "OnChange"};
     std::vector<std::string> tValues = {"SystemCall", 
         "wait", 
-        "while lsof -u $USER | grep ./file; do sleep 1; done", 
+        "while lsof -u `id -u -n` | grep ./file; do sleep 1; done", 
         "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);
 
@@ -138,7 +138,7 @@ TEST(OperationTest, WriteDefinitionWaitOperationWithTag)
         "OnChange"};
     std::vector<std::string> tValues = {"SystemCall", 
         "wait_{E}", 
-        "while lsof -u $USER | grep ./file; do sleep 1; done", 
+        "while lsof -u `id -u -n` | grep ./file; do sleep 1; done", 
         "evaluations_{E}",
         "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);

--- a/base/src/input_generator/unittest/PlatoGemma_UnitTester.cpp
+++ b/base/src/input_generator/unittest/PlatoGemma_UnitTester.cpp
@@ -260,7 +260,7 @@ TEST(PlatoTestXMLGenerator, WriteGemmaPlatoMainOperationsFile)
         "OnChange"};
     tValues = {"SystemCall", 
         "wait_0", 
-        "while lsof -u $USER | grep ./matched_power_balance.dat; do sleep 1; done", 
+        "while lsof -u `id -u -n` | grep ./matched_power_balance.dat; do sleep 1; done", 
         "evaluations_0",
         "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);
@@ -269,7 +269,7 @@ TEST(PlatoTestXMLGenerator, WriteGemmaPlatoMainOperationsFile)
     ASSERT_FALSE(tOperation.empty());
     tValues = {"SystemCall", 
         "wait_1", 
-        "while lsof -u $USER | grep ./matched_power_balance.dat; do sleep 1; done", 
+        "while lsof -u `id -u -n` | grep ./matched_power_balance.dat; do sleep 1; done", 
         "evaluations_1",
         "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);

--- a/base/src/input_generator/unittest/XMLGeneratorPlatoMainOperationFile_UnitTester.cpp
+++ b/base/src/input_generator/unittest/XMLGeneratorPlatoMainOperationFile_UnitTester.cpp
@@ -2243,7 +2243,7 @@ TEST(PlatoTestXMLGenerator, AppendWaitForFileToPlatoMainOperation)
     std::vector<std::string> tKeys = {"Function", "Name", 
         "Command", "OnChange"};
     std::vector<std::string> tValues = {"SystemCall", "wait", 
-        "while lsof -u $USER | grep folder/file; do sleep 1; done; ", "false"};
+        "while lsof -u `id -u -n` | grep folder/file; do sleep 1; done; ", "false"};
     PlatoTestXMLGenerator::test_children(tKeys, tValues, tOperation);
   
 }

--- a/regression/XMLOutput/Dakota_MDPS_Gemma/xmlout.gold
+++ b/regression/XMLOutput/Dakota_MDPS_Gemma/xmlout.gold
@@ -108,21 +108,21 @@ PlatoEngineServices plato_main_input_deck.xml \
 <Operation>
   <Function>SystemCall</Function>
   <Name>wait_0</Name>
-  <Command>while lsof -u $USER | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
+  <Command>while lsof -u `id -u -n` | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
   <ChDir>evaluations_0</ChDir>
   <OnChange>false</OnChange>
 </Operation>
 <Operation>
   <Function>SystemCall</Function>
   <Name>wait_1</Name>
-  <Command>while lsof -u $USER | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
+  <Command>while lsof -u `id -u -n` | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
   <ChDir>evaluations_1</ChDir>
   <OnChange>false</OnChange>
 </Operation>
 <Operation>
   <Function>SystemCall</Function>
   <Name>wait_2</Name>
-  <Command>while lsof -u $USER | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
+  <Command>while lsof -u `id -u -n` | grep ./gemma_matched_power_balance_input_deck_power_balance.dat; do sleep 1; done</Command>
   <ChDir>evaluations_2</ChDir>
   <OnChange>false</OnChange>
 </Operation>


### PR DESCRIPTION
Tracked down the issue on lumbergh to the environment variable USER not being defined when the tests are run. This change switches to using the POSIX-compatible command id to get the username. I compiled the changes, but didn't run any tests. Hoping that this will make it in to nightly testing prior to tomorrow so that we can confirm that it works.