### PR TITLE
TO-4950: Updates Analyze_IS_ESP test

### DIFF
--- a/regression/Analyze_IS_ESP/opt.py
+++ b/regression/Analyze_IS_ESP/opt.py
@@ -132,11 +132,35 @@ def dfdx(x, grad):
   
     return value
 
+def gradient_exception_exit_code(err):
+  if "HATCHING_GRADIENT" in str(err):
+    print("passed")
+    return 0
+  else:
+    print("Expected HATCHING_GRADIENT in error message")
+    print("failed")
+    return 1
+
+def dfdx_with_gradient_exception_check(xinit, gradP, hatching_gradient_enabled):
+  if hatching_gradient_enabled:
+    return dfdx(xinit, gradP) # f(x)
+  else:
+    try:
+      dfdx(xinit, gradP)
+    except RuntimeError as err:
+      print(f"Caught expected exception: {err}")
+      sys.exit(gradient_exception_exit_code(err))
+    else:
+      print("This test is expecting hatching gradients to be disabled, which is detected via an exception.")
+      print("An exception is thrown if HATCHING_GRADIENT is disabled in the platoanalyze build, but was not caught.")
+      print("If hatching gradients have been fixed, this check can be removed.")
+      print("failed")
+      sys.exit(1)
 
 xinit = [1.0, 1.0, 1.0, 0.25]
 gradP = [0.0 for i in range(len(xinit))]
+f_x = dfdx_with_gradient_exception_check(xinit, gradP, hatching_gradient_enabled=False)
 
-f_x = dfdx(xinit, gradP) # f(x)
 g_x = array(gradP) # f'(x)
 x = array(xinit)
 

--- a/regression/Analyze_IS_ESP/plato_analyze_input_deck_1.xml
+++ b/regression/Analyze_IS_ESP/plato_analyze_input_deck_1.xml
@@ -9,7 +9,7 @@
 
   <ParameterList name="Plato Problem">
     <Parameter name="Physics"         type="string"  value="Mechanical"/>
-    <Parameter name="PDE Constraint"  type="string"  value="Updated Lagrangian Elliptic"/>
+    <Parameter name="PDE Constraint"  type="string"  value="Elliptic Hatching"/>
 
     <ParameterList name="Criteria">
       <ParameterList name="Volume">


### PR DESCRIPTION
Changes the Analyze_IS_ESP test to expect an exception. The hatching gradients were disabled and an exception is thrown when that function is called. The test checks for that exception and an expected error message.