### PR TITLE
TO-5134: Increases minimum_ersatz_material_value

### DIFF
--- a/examples/Analyze_Helmholtz3D_SurfaceLengthScale_SymmPlane/plato_input_deck.i
+++ b/examples/Analyze_Helmholtz3D_SurfaceLengthScale_SymmPlane/plato_input_deck.i
@@ -12,7 +12,7 @@ end service
 
 begin criterion 1
   type mechanical_compliance
-  minimum_ersatz_material_value 1e-9
+  minimum_ersatz_material_value 1e-3
 end criterion
 
 begin criterion 2
@@ -25,7 +25,7 @@ begin scenario 1
   loads 1
   boundary_conditions 1 2
   material 1
-  minimum_ersatz_material_value 1e-9
+  minimum_ersatz_material_value 1e-3
   linear_solver_tolerance 1e-8
 end scenario
 


### PR DESCRIPTION
The lower value resulted in a ill-conditioned matrix, which Tacho could not solve. The value also now matches the other Helmholtz3D test. TO-5134