### PR TITLE
Console output fixes:

### DIFF
--- a/base/src/optimize/Plato_ROLInterface.hpp
+++ b/base/src/optimize/Plato_ROLInterface.hpp
@@ -107,7 +107,6 @@ public:
         bool tPrintToStream = true;
         
         tOptimizationProblem->finalize(tLumpConstraints, tPrintToStream, mOutputFile);
-        //tOptimizationProblem->finalize(tLumpConstraints, tPrintToStream, std::cout);
 
         if(this->mInputData.getCheckGradient() == true)
         {

--- a/base/src/optimize/Plato_ROLInterface.hpp
+++ b/base/src/optimize/Plato_ROLInterface.hpp
@@ -106,7 +106,8 @@ public:
         bool tLumpConstraints = ( mAlgorithmType == Plato::optimizer::algorithm_t::ROL_LINEAR_CONSTRAINT ? false : true );
         bool tPrintToStream = true;
         
-        tOptimizationProblem->finalize(tLumpConstraints, tPrintToStream, std::cout);
+        tOptimizationProblem->finalize(tLumpConstraints, tPrintToStream, mOutputFile);
+        //tOptimizationProblem->finalize(tLumpConstraints, tPrintToStream, std::cout);
 
         if(this->mInputData.getCheckGradient() == true)
         {
@@ -177,6 +178,7 @@ private:
         ROL::Solver<ScalarType> tOptimizer(aOptimizationProblem, *tParameterList);
         std::ostream outputStream(this->mOutputBuffer);
         tOptimizer.solve(outputStream);
+        outputStream.flush();
         this->printControl(aOptimizationProblem);
     }
 
@@ -200,7 +202,8 @@ private:
             ROL::Ptr<const ROL::TypeB::AlgorithmState<ScalarType>> tAlgorithmState =
                     ROL::staticPtrCast<const ROL::TypeB::AlgorithmState<ScalarType>>(tOptimizer.getAlgorithmState());
             tCurDelta = tAlgorithmState->searchSize;
-            std::cout << "Delta: " << tCurDelta << std::endl;
+            outputStream << "Delta: " << tCurDelta << std::endl;
+            outputStream.flush();
         }
         this->printControl(aOptimizationProblem);
     }
@@ -390,6 +393,13 @@ protected:
     void finalize()
     {
         this->mInterface->finalize();
+/*
+        if(mOutputFile.is_open())
+        {
+            mOutputFile.flush();
+            mOutputFile.close();
+        }
+*/
     }
 };
 

--- a/base/src/optimize/Plato_ROLInterface.hpp
+++ b/base/src/optimize/Plato_ROLInterface.hpp
@@ -392,13 +392,6 @@ protected:
     void finalize()
     {
         this->mInterface->finalize();
-/*
-        if(mOutputFile.is_open())
-        {
-            mOutputFile.flush();
-            mOutputFile.close();
-        }
-*/
     }
 };
 

--- a/base/src/tools/Plato_Console.cpp
+++ b/base/src/tools/Plato_Console.cpp
@@ -60,8 +60,6 @@
 namespace Plato
 {
 
-std::streambuf* Console::mStreamBufferCout = nullptr;
-std::fstream*   Console::mConsoleFile = nullptr;
 bool Console::mRedirectable = false;
 bool Console::mVerbose = false;
 bool Console::mEnabled = false;
@@ -98,30 +96,6 @@ Console::Console(const std::string & aPerformerName, int aPerformerID, InputData
 
    if( mEnabled )
    {
-/*
-       if( mStreamBufferCout == nullptr )
-       {
-           mStreamBufferCout = std::cout.rdbuf();
-       }
-
-       if( mConsoleFile == nullptr )
-       {
-           std::stringstream tNameStream;
-           tNameStream << mPerformerName << "_" << mPerformerID;
-
-           mConsoleFile = new std::fstream;
-           mConsoleFile->open(tNameStream.str(), std::ios::out);
-           redirect_cout();
-
-           m_redir_fd = open(tNameStream.str().c_str(), O_WRONLY);
-           m_stdout_fd = dup(STDOUT_FILENO);
-           m_stderr_fd = dup(STDERR_FILENO);
-           redirect_printf();
-
-           mRedirectable = true;
-       }
-*/
-
        std::stringstream tNameStream;
        tNameStream << mPerformerName << "_" << mPerformerID;
 
@@ -144,14 +118,6 @@ Console::~Console()
 {
    restore();
 
-/*
-   if (mConsoleFile != nullptr)
-   {
-      mConsoleFile->close();
-      delete mConsoleFile;
-   }
-*/
-
    if (mRedirectable )
    {
       close(m_redir_fd);
@@ -164,7 +130,6 @@ void Console::restore()
 {
    if (mRedirectable)
    {
-//      restore_cout();
       restore_printf();
    }
 }
@@ -173,7 +138,6 @@ void Console::redirect()
 {
    if (mRedirectable)
    {
-//      redirect_cout();
       redirect_printf();
    }
 }
@@ -184,29 +148,6 @@ void Console::redirect_printf()
    fflush(stderr);
    dup2(m_redir_fd, STDOUT_FILENO);
    dup2(m_redir_fd, STDERR_FILENO);
-}
-
-void Console::redirect_cout()
-{
-/*
-
-   if (mConsoleFile != nullptr)
-   {
-     std::flush(std::cout);
-     std::cout.rdbuf(mConsoleFile->rdbuf());
-   }
-*/
-}
-
-void Console::restore_cout()
-{
-/*
-   if (mStreamBufferCout != nullptr)
-   {
-     std::flush(std::cout);
-     std::cout.rdbuf(mStreamBufferCout);
-   }
-*/
 }
 
 void Console::restore_printf()

--- a/base/src/tools/Plato_Console.cpp
+++ b/base/src/tools/Plato_Console.cpp
@@ -98,6 +98,7 @@ Console::Console(const std::string & aPerformerName, int aPerformerID, InputData
 
    if( mEnabled )
    {
+/*
        if( mStreamBufferCout == nullptr )
        {
            mStreamBufferCout = std::cout.rdbuf();
@@ -119,6 +120,19 @@ Console::Console(const std::string & aPerformerName, int aPerformerID, InputData
 
            mRedirectable = true;
        }
+*/
+
+       std::stringstream tNameStream;
+       tNameStream << mPerformerName << "_" << mPerformerID;
+
+       m_redir_fd = open(tNameStream.str().c_str(), O_WRONLY | O_CREAT | O_TRUNC, 
+                                S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+       m_stdout_fd = dup(STDOUT_FILENO);
+       m_stderr_fd = dup(STDERR_FILENO);
+       redirect_printf();
+
+       mRedirectable = true;
+
    }
    else
    {
@@ -130,11 +144,13 @@ Console::~Console()
 {
    restore();
 
+/*
    if (mConsoleFile != nullptr)
    {
       mConsoleFile->close();
       delete mConsoleFile;
    }
+*/
 
    if (mRedirectable )
    {
@@ -148,7 +164,7 @@ void Console::restore()
 {
    if (mRedirectable)
    {
-      restore_cout();
+//      restore_cout();
       restore_printf();
    }
 }
@@ -157,7 +173,7 @@ void Console::redirect()
 {
    if (mRedirectable)
    {
-      redirect_cout();
+//      redirect_cout();
       redirect_printf();
    }
 }
@@ -172,21 +188,25 @@ void Console::redirect_printf()
 
 void Console::redirect_cout()
 {
+/*
 
    if (mConsoleFile != nullptr)
    {
      std::flush(std::cout);
      std::cout.rdbuf(mConsoleFile->rdbuf());
    }
+*/
 }
 
 void Console::restore_cout()
 {
+/*
    if (mStreamBufferCout != nullptr)
    {
      std::flush(std::cout);
      std::cout.rdbuf(mStreamBufferCout);
    }
+*/
 }
 
 void Console::restore_printf()

--- a/base/src/tools/Plato_Console.hpp
+++ b/base/src/tools/Plato_Console.hpp
@@ -69,8 +69,6 @@ public:
     static void Alert(std::string aAlertMessage);
     static void Status(std::string aStatusMessage);
 
-    static std::streambuf* mStreamBufferCout;
-
 private:
     std::string mPerformerName;
     int mPerformerID;
@@ -82,8 +80,6 @@ private:
     static int m_stdout_fd;
     static int m_stderr_fd;
     static int m_redir_fd;
-
-    static std::fstream* mConsoleFile;
 
     static void redirect();
     static void restore();

--- a/base/src/tools/Plato_OptimizerEngineStageData.cpp
+++ b/base/src/tools/Plato_OptimizerEngineStageData.cpp
@@ -60,7 +60,7 @@ OptimizerEngineStageData::OptimizerEngineStageData() :
         mCheckHessian(false),
         mUserInitialGuess(false),
         mOutputControlToFile(false),
-        mOutputDiagnosticsToFile(false),
+        mOutputDiagnosticsToFile(true),
         mDisablePostSmoothing(false),
         mResetAlgorithmOnUpdate(false),
         mMaxNumAugLagSubProbIter(5),


### PR DESCRIPTION
1) Fixed issue with log files being overwritten.
2) Output ROL output to ROL_output.txt by default. <OutputDiagnosticsToFile>false</OutputDiagnosticsToFile> in the Optimizer options section of interface.xml will turn this off so ROL output goes to the console or platomain_1_0 depending on whether stdout was redirected.