### PR TITLE
TO-5179: Adds constrained Application interface

### DIFF
--- a/base/src/interface/CMakeLists.txt
+++ b/base/src/interface/CMakeLists.txt
@@ -6,6 +6,7 @@ set(${LIB_NAME}_SOURCES Plato_Interface.cpp
                         Plato_Operation.cpp
                         Plato_MultiOperation.cpp
                         Plato_SingleOperation.cpp
+                        Plato_FunctionOperation.cpp
                         Plato_OperationFactory.cpp
                         Plato_Stage.cpp
                         Plato_Performer.cpp)
@@ -13,6 +14,7 @@ set(${LIB_NAME}_HEADERS Plato_Application.hpp
                         Plato_Interface.hpp
                         Plato_Operation.hpp
                         Plato_MultiOperation.hpp
+                        Plato_FunctionOperation.hpp
                         Plato_SingleOperation.hpp
                         Plato_OperationFactory.hpp
                         Plato_Stage.hpp

--- a/base/src/interface/Plato_Application.hpp
+++ b/base/src/interface/Plato_Application.hpp
@@ -55,6 +55,7 @@
 #include <vector>
 
 #include "Plato_SharedData.hpp"
+#include "Plato_OperationTypes.hpp"
 
 namespace Plato
 {
@@ -65,9 +66,7 @@ namespace Plato
 class Application
 {
 public:
-    virtual ~Application()
-    {
-    }
+    virtual ~Application() = default;
 
     virtual void finalize() = 0;
     virtual void initialize() = 0;
@@ -77,6 +76,18 @@ public:
     virtual void exportDataMap(const Plato::data::layout_t & aDataLayout, std::vector<int> & aMyOwnedGlobalIDs) = 0;
 
     virtual void reinitialize() { std::cout << "WARNING: default Plato::Application::reinitialize() was called." << std::endl; }
+
+    //!@{
+    //! Constrained interface functions
+    //!
+    //! The purpose of this interface is to clarify which functions derived classes must
+    //! implement. 
+    bool usesConstrainedOperationInterface() const {return !supportedOperationTypes().empty();}
+    virtual void computeCriterionValue(){} 
+    virtual void computeCriterionGradient(){}
+    virtual void computeCriterionHessianTimesVector(){}
+    virtual std::vector<OperationType> supportedOperationTypes() const{return {};}
+    //!@}
 };
 
 } // End namespace Plato

--- a/base/src/interface/Plato_CriterionApplication.hpp
+++ b/base/src/interface/Plato_CriterionApplication.hpp
@@ -1,0 +1,24 @@
+#ifndef SRC_OBJECTIVEAPPLICATION_HPP_
+#define SRC_OBJECTIVEAPPLICATION_HPP_
+
+#include "Plato_Application.hpp"
+
+namespace Plato{
+/// An Application that implements the criterion constrained interface.
+///
+/// The purpose of this class is to be a base class for objective-based applications.
+/// I.e. applications that only represent objective functions and not constraints or
+/// other operations.
+class CriterionApplication : public Application
+{
+public:
+    void computeCriterionValue() override = 0; 
+    void computeCriterionGradient() override = 0;
+    void computeCriterionHessianTimesVector() override = 0;
+    virtual std::vector<OperationType> supportedOperationTypes() const
+    { 
+        return {OperationType::kCriterionValue, OperationType::kCriterionGradient, OperationType::kCriterionHessian};
+    }
+};
+}
+#endif

--- a/base/src/interface/Plato_FunctionOperation.cpp
+++ b/base/src/interface/Plato_FunctionOperation.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include <algorithm>
+#include <sstream>
+
+#include "Plato_Exceptions.hpp"
+#include "Plato_FunctionOperation.hpp"
+#include "Plato_Performer.hpp"
+#include "Plato_SharedData.hpp"
+#include "Plato_Utils.hpp"
+#include "Plato_OperationInputDataMng.hpp"
+#include "Plato_EnumTable.hpp"
+
+namespace Plato {
+
+namespace {
+std::string unrecognizedOperationErrorMessage(
+    const std::string& aErroneousOperation, 
+    const Performer& aPerformer)
+{
+    std::string errorMessage = R"(Unknown operation ")" + aErroneousOperation + R"(". Performer supports: )";
+    for(const OperationType operation : aPerformer.supportedOperationTypes())
+    {
+        errorMessage += "\n  " + operationTypeName(operation);
+    }
+    return errorMessage;
+}
+}
+
+/******************************************************************************/
+FunctionOperation::
+FunctionOperation(const Plato::OperationInputDataMng & aOperationDataMng,
+               const std::shared_ptr<Plato::Performer> aPerformer,
+               const std::vector<Plato::SharedData*>& aSharedData) :
+  Operation(aOperationDataMng, aPerformer, aSharedData)
+/******************************************************************************/
+{
+    initialize(aOperationDataMng, aPerformer, aSharedData);
+}
+
+/******************************************************************************/
+void
+FunctionOperation::
+initialize(const Plato::OperationInputDataMng & aOperationDataMng,
+           const std::shared_ptr<Plato::Performer> aPerformer,
+           const std::vector<Plato::SharedData*>& aSharedData)
+/******************************************************************************/
+{
+    initializeBaseSingle(aOperationDataMng, aPerformer, aSharedData);
+    const boost::optional<OperationType> tOperation = 
+        aOperationDataMng.getOperationType(aPerformer->myName());
+    if(!tOperation)
+    {
+        // todo: Is ParsingException the correct exception type?
+        throw ParsingException(unrecognizedOperationErrorMessage(
+            aOperationDataMng.getOperationName(aPerformer->myName()),
+            *aPerformer
+        ));
+    }
+    mComputeFunction = Performer::computeFunction(*tOperation);
+}
+
+void FunctionOperation::computeImpl() 
+{
+    mComputeFunction(*m_performer);
+}
+
+/******************************************************************************/
+void FunctionOperation::
+update(const Plato::OperationInputDataMng & aOperationDataMng,
+       const std::shared_ptr<Plato::Performer> aPerformer,
+       const std::vector<Plato::SharedData*>& aSharedData)
+/******************************************************************************/
+{
+    // If the shared data is recreated then the operation must be
+    // updated so to have the new links to the shared data.
+    initialize(aOperationDataMng, aPerformer, aSharedData);
+}
+
+} // End namespace Plato

--- a/base/src/interface/Plato_FunctionOperation.hpp
+++ b/base/src/interface/Plato_FunctionOperation.hpp
@@ -1,0 +1,43 @@
+#ifndef SRC_FUNCTION_OPERATION_HPP_
+#define SRC_FUNCTION_OPERATION_HPP_
+
+#include <map>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include "Plato_Operation.hpp"
+
+namespace Plato
+{
+
+class Performer;
+class SharedData;
+class OperationInputDataMng;
+
+/// 
+class FunctionOperation final : public Operation
+{
+public:
+    FunctionOperation(const Plato::OperationInputDataMng & aOperationDataMng,
+                    const std::shared_ptr<Plato::Performer> aPerformer,
+                    const std::vector<Plato::SharedData*>& aSharedData);
+
+    void update(const ::Plato::OperationInputDataMng & aOperationDataMng,
+                        const std::shared_ptr<::Plato::Performer> aPerformer,
+                        const std::vector<::Plato::SharedData*>& aSharedData) override;
+
+    void initialize(const ::Plato::OperationInputDataMng & aOperationDataMng,
+                    const std::shared_ptr<::Plato::Performer> aPerformer,
+                    const std::vector<::Plato::SharedData*>& aSharedData);
+
+protected:
+    void computeImpl() override;
+
+private:
+    std::function<void(Performer&)> mComputeFunction;
+};
+
+} // End namespace Plato
+
+#endif

--- a/base/src/interface/Plato_MultiOperation.cpp
+++ b/base/src/interface/Plato_MultiOperation.cpp
@@ -218,6 +218,7 @@ initialize(const Plato::OperationInputDataMng & aOperationDataMng,
             break;
         }
     }
+
 }
 
 /******************************************************************************/

--- a/base/src/interface/Plato_Operation.hpp
+++ b/base/src/interface/Plato_Operation.hpp
@@ -80,7 +80,7 @@ public:
 
     virtual void sendInput();
     virtual void sendOutput();
-    virtual void compute();
+    void compute();
 
     virtual void importData(std::string sharedDataName, Plato::SharedData* sf);
     virtual void exportData(std::string sharedDataName, Plato::SharedData* sf);
@@ -98,10 +98,18 @@ public:
 
 protected:
 
+    /// @pre m_performer must not be `nullptr`.
+    virtual void computeImpl();
+
     void addArgument(const std::string & tArgumentName,
                      const std::string & tSharedDataName,
                      const std::vector<Plato::SharedData*>& aSharedData,
                      std::vector<Plato::SharedData*>& aLocalData);
+
+    void initializeBaseSingle(
+      const Plato::OperationInputDataMng & aOperationDataMng,
+      const std::shared_ptr<Plato::Performer> aPerformer,
+      const std::vector<Plato::SharedData*>& aSharedData);
 
     class Parameter : public Plato::SharedData {
       const std::string m_name;

--- a/base/src/interface/Plato_OperationFactory.cpp
+++ b/base/src/interface/Plato_OperationFactory.cpp
@@ -57,6 +57,7 @@
 #include "Plato_Operation.hpp"
 #include "Plato_MultiOperation.hpp"
 #include "Plato_SingleOperation.hpp"
+#include "Plato_FunctionOperation.hpp"
 
 #include "Plato_Parser.hpp"
 #include "Plato_Performer.hpp"
@@ -76,12 +77,21 @@ OperationFactory::create(
 {
     Plato::InputData inputNode = aOperationDataMng.get<Plato::InputData>("Input Data");
 
-    std::string opType = inputNode.name();
+    const std::string opType = inputNode.name();
     if( opType == "Operation" ){
-      bool tHasSubOperations = aOperationDataMng.hasSubOperations();
+      const bool tHasSubOperations = aOperationDataMng.hasSubOperations();
+      
       if(tHasSubOperations == true)
       {
+        if(aPerformer->usesConstrainedOperationInterface())
+        {
+          throw std::runtime_error("This app does not support suboperations.");
+        }
         return new MultiOperation(aOperationDataMng, aPerformer, aSharedData);
+      }
+      else if(aPerformer->usesConstrainedOperationInterface())
+      {
+        return new FunctionOperation(aOperationDataMng, aPerformer, aSharedData);
       }
       else
       {

--- a/base/src/interface/Plato_Performer.cpp
+++ b/base/src/interface/Plato_Performer.cpp
@@ -78,6 +78,33 @@ void Performer::compute(const std::string & aOperationName)
     }
 }
 
+void Performer::computeCriterionValue()
+{
+    if(mApplication)
+    {
+        Console::Status("Operation: (" + mName + ") Compute Objective");
+        mApplication->computeCriterionValue();
+    }
+}
+
+void Performer::computeCriterionGradient()
+{
+    if(mApplication)
+    {
+        Console::Status("Operation: (" + mName + ") Compute Gradient");
+        mApplication->computeCriterionGradient();
+    }
+}
+
+void Performer::computeCriterionHessianTimesVector()
+{
+    if(mApplication)
+    {
+        Console::Status("Operation: (" + mName + ") Compute Hessian");
+        mApplication->computeCriterionHessianTimesVector();
+    }
+}
+
 void Performer::importData(const std::string & aArgumentName, const SharedData & aImportData)
 {
     if(mApplication)
@@ -112,6 +139,47 @@ std::string Performer::myName()
 int Performer::myCommID()
 {
     return mCommID;
+}
+
+bool Performer::usesConstrainedOperationInterface() const 
+{
+    if(mApplication)
+    {
+        return mApplication->usesConstrainedOperationInterface();
+    }
+    else 
+    {
+        return false;
+    }
+}
+
+std::vector<OperationType> Performer::supportedOperationTypes() const
+{
+    if(mApplication)
+    {
+        return mApplication->supportedOperationTypes();
+    }
+    else
+    {
+        return {};
+    }
+}
+
+auto Performer::computeFunction(OperationType aOperation) -> std::function<void(Performer&)>
+{
+    switch(aOperation)
+    {
+        case OperationType::kCriterionValue:
+            return std::mem_fn(&Performer::computeCriterionValue);
+            break;
+        case OperationType::kCriterionGradient:
+            return std::mem_fn(&Performer::computeCriterionGradient);
+            break;
+        case OperationType::kCriterionHessian:
+        default:
+            return std::mem_fn(&Performer::computeCriterionHessianTimesVector);
+            break;
+    }
 }
 
 }

--- a/base/src/interface/Plato_Performer.hpp
+++ b/base/src/interface/Plato_Performer.hpp
@@ -50,7 +50,10 @@
 #ifndef SRC_PERFORMER_HPP_
 #define SRC_PERFORMER_HPP_
 
+#include "Plato_OperationTypes.hpp"
+
 #include <string>
+#include <vector>
 
 namespace Plato
 {
@@ -69,6 +72,7 @@ public:
     void finalize();
     void compute(const std::string & aOperationName);
 
+
     void importData(const std::string & aArgumentName, const SharedData & aImportData);
     void exportData(const std::string & aArgumentName, SharedData & aExportData);
 
@@ -78,7 +82,18 @@ public:
     std::string myName();
     int myCommID();
 
+    //!{
+    //! Constrained interface
+    bool usesConstrainedOperationInterface() const;
+    std::vector<OperationType> supportedOperationTypes() const;
+    static auto computeFunction(OperationType aOperation) -> std::function<void(Performer&)>;
+    //!}
+
 private:
+    void computeCriterionValue();
+    void computeCriterionGradient();
+    void computeCriterionHessianTimesVector();
+
     Application* mApplication;  // TODO make this a unique pointer
     const std::string mName;
     const int mCommID;

--- a/base/src/interface/Plato_SingleOperation.cpp
+++ b/base/src/interface/Plato_SingleOperation.cpp
@@ -68,7 +68,7 @@ SingleOperation(const Plato::OperationInputDataMng & aOperationDataMng,
   Operation(aOperationDataMng, aPerformer, aSharedData)
 /******************************************************************************/
 {
-    this->initialize(aOperationDataMng, aPerformer, aSharedData);
+    initialize(aOperationDataMng, aPerformer, aSharedData);
 }
 
 /******************************************************************************/
@@ -79,50 +79,7 @@ initialize(const Plato::OperationInputDataMng & aOperationDataMng,
            const std::vector<Plato::SharedData*>& aSharedData)
 /******************************************************************************/
 {
-    m_performer = nullptr;
-    m_parameters.clear();
-    m_inputData.clear();
-    m_outputData.clear();
-    m_argumentNames.clear();
-
-    const std::string & tPerformerName = aOperationDataMng.getPerformerName();
-    m_operationName = aOperationDataMng.getOperationName(tPerformerName);
-
-    auto tAllParamsData = aOperationDataMng.get<Plato::InputData>("Parameters");
-    if( tAllParamsData.size<Plato::InputData>(tPerformerName) )
-    {
-        auto tParamsData = tAllParamsData.get<Plato::InputData>(tPerformerName);
-        for( auto tParamData : tParamsData.getByName<Plato::InputData>("Parameter") )
-        {
-            auto tArgName  = Plato::Get::String(tParamData,"ArgumentName");
-            auto tArgValue = Plato::Get::Double(tParamData,"ArgumentValue");
-            m_parameters.insert(
-              std::pair<std::string, Parameter*>(tArgName, new Parameter(tArgName, m_operationName, tArgValue)));
-        }
-    }
-
-    // Get the input shared data.
-    const int tNumInputs = aOperationDataMng.getNumInputs(tPerformerName);
-    for(int tInputIndex = 0; tInputIndex < tNumInputs; tInputIndex++)
-    {
-        const std::string & tArgumentName = aOperationDataMng.getInputArgument(tPerformerName, tInputIndex);
-        const std::string & tSharedDataName = aOperationDataMng.getInputSharedData(tPerformerName, tInputIndex);
-        this->addArgument(tArgumentName, tSharedDataName, aSharedData, m_inputData);
-    }
-
-    // Get the output shared data.
-    const int tNumOutputs = aOperationDataMng.getNumOutputs(tPerformerName);
-    for(int tOutputIndex = 0; tOutputIndex < tNumOutputs; tOutputIndex++)
-    {
-        const std::string & tArgumentName = aOperationDataMng.getOutputArgument(tPerformerName, tOutputIndex);
-        const std::string & tSharedDataName = aOperationDataMng.getOutputSharedData(tPerformerName, tOutputIndex);
-        this->addArgument(tArgumentName, tSharedDataName, aSharedData, m_outputData);
-    }
-
-    if(aPerformer->myName() == tPerformerName)
-    {
-        m_performer = aPerformer;
-    }
+    initializeBaseSingle(aOperationDataMng, aPerformer, aSharedData);
 }
 
 
@@ -136,7 +93,7 @@ update(const Plato::OperationInputDataMng & aOperationDataMng,
     // If the shared data is recreated then the operation must be
     // updated so to have the new links to the shared data.
 
-    this->initialize(aOperationDataMng, aPerformer, aSharedData);
+    initialize(aOperationDataMng, aPerformer, aSharedData);
 }
 
 } // End namespace Plato

--- a/base/src/tools/CMakeLists.txt
+++ b/base/src/tools/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${LIB_NAME}_SOURCES Plato_Parser.cpp
                         Plato_Vector3DVariations.cpp
                         Plato_AppErrorChecks.cpp
                         Plato_ParseCSMUtilities.cpp
+                        Plato_OperationTypes.cpp
                         )
 set(${LIB_NAME}_HEADERS Plato_Parser.hpp
                         Plato_Macros.hpp
@@ -30,6 +31,8 @@ set(${LIB_NAME}_HEADERS Plato_Parser.hpp
                         Plato_AppErrorChecks.hpp
                         Plato_Vector3DVariations.hpp
                         Plato_ParseCSMUtilities.hpp
+                        Plato_OperationTypes.hpp
+                        Plato_EnumTable.hpp
                         )
 
 set(LIB_NAME Exceptions)

--- a/base/src/tools/Plato_EnumTable.hpp
+++ b/base/src/tools/Plato_EnumTable.hpp
@@ -1,0 +1,89 @@
+#ifndef SRC_ENUMTABLE_HPP_
+#define SRC_ENUMTABLE_HPP_
+
+#include <boost/optional.hpp>
+#include <boost/bimap.hpp>
+#include <boost/bimap/unordered_set_of.hpp>
+
+#include <type_traits>
+#include <string>
+#include <initializer_list>
+#include <utility>
+
+namespace Plato{
+
+/// A convenience type for mapping enums to strings.
+///
+/// The purpose of this class is to facilitate serialization of enumerations. Directly 
+/// serializing enumerations as integers is difficult to read in an input file, so this 
+/// class provides a mapping to a string. Usage is typically as static data.
+/// @todo Add serialization.
+template<typename Enum>
+class EnumTable
+{
+    static_assert(std::is_enum<Enum>::value, "EnumTable must be instantiated with an enum type.");
+
+    using MapType = boost::bimap<boost::bimaps::unordered_set_of<Enum>, 
+        boost::bimaps::unordered_set_of<std::string>>;
+    using ValueType = typename MapType::value_type;
+
+public:
+
+    EnumTable() = default;
+
+    /// All entries in @a aEnumPairs must be unique, for both left and right sides. I.e.
+    /// no enum or string can be equal. Checked with an assertion.
+    EnumTable(std::initializer_list<std::pair<Enum, std::string>> aEnumPairs);
+
+    /// @todo: Change return to std::optional in c++17
+    boost::optional<Enum> toEnum(const std::string& aString) const;
+
+    /// @todo: Change return to std::optional in c++17
+    boost::optional<std::string> toString(const Enum aEnum) const;
+
+private:
+    boost::bimap<Enum, std::string> mMap;
+};
+
+template<typename Enum>
+EnumTable<Enum>::EnumTable(std::initializer_list<std::pair<Enum, std::string>> aEnumPairs)
+{
+    for(const auto& tItem : aEnumPairs)
+    {
+        // Must not contain duplicates
+        assert(mMap.left.count(tItem.first) == 0 && mMap.right.count(tItem.second) == 0);
+        mMap.insert(ValueType{tItem.first, tItem.second});
+    }
+}
+
+template<typename Enum>
+boost::optional<Enum> EnumTable<Enum>::toEnum(const std::string& aString) const
+{
+    const auto tIter = mMap.right.find(aString);
+    if(tIter != mMap.right.end())
+    {
+        return tIter->second;
+    }
+    else
+    {
+        return boost::none;
+    }
+}
+
+template<typename Enum>
+boost::optional<std::string> EnumTable<Enum>::toString(const Enum aEnum) const
+{
+    const auto tIter = mMap.left.find(aEnum);
+    if(tIter != mMap.left.end())
+    {
+       return tIter->second;
+    }
+    else
+    {
+       return boost::none;
+    }
+}
+
+}
+
+#endif

--- a/base/src/tools/Plato_FreeFunctions.cpp
+++ b/base/src/tools/Plato_FreeFunctions.cpp
@@ -177,4 +177,12 @@ void fread(void* aBuffer, std::size_t aSize, std::size_t aCount, std::FILE* aFil
 }
 /**********************************************************************************/
 
+/**********************************************************************************/
+std::string stripSpaces(std::string aStr)
+{
+    const auto tIsSpace = [](const char aC){return aC == ' ';};
+    aStr.erase(std::remove_if(aStr.begin(), aStr.end(), tIsSpace), aStr.end());
+    return aStr;
+}
+/**********************************************************************************/
 } // end namespace Plato

--- a/base/src/tools/Plato_FreeFunctions.hpp
+++ b/base/src/tools/Plato_FreeFunctions.hpp
@@ -140,4 +140,6 @@ int system_with_status(const char* aString);
 
 void fread(void* aBuffer, std::size_t aSize, std::size_t aCount, std::FILE* aFile);
 
+std::string stripSpaces(std::string aStr);
+
 } // end namespace Plato

--- a/base/src/tools/Plato_OperationInputDataMng.cpp
+++ b/base/src/tools/Plato_OperationInputDataMng.cpp
@@ -140,6 +140,14 @@ const std::string & OperationInputDataMng::getOperationName(const std::string & 
 }
 
 /*****************************************************************************/
+boost::optional<OperationType> OperationInputDataMng::getOperationType(const std::string & aPerformerName) const
+/*****************************************************************************/
+{
+    // todo: We can probably handle the error checking of the optional on addInput
+    return operationTypeIgnoreSpaces(getOperationName(aPerformerName));
+}
+
+/*****************************************************************************/
 int OperationInputDataMng::getNumInputs(const int & aOperationIndex) const
 /*****************************************************************************/
 {

--- a/base/src/tools/Plato_OperationInputDataMng.hpp
+++ b/base/src/tools/Plato_OperationInputDataMng.hpp
@@ -55,6 +55,9 @@
 #include <utility>
 
 #include "Plato_InputData.hpp"
+#include "Plato_OperationTypes.hpp"
+
+#include <boost/optional.hpp>
 
 namespace Plato
 {
@@ -73,6 +76,7 @@ public:
     const std::string & getPerformerName(const int & aOperationIndex) const;
     const std::string & getOperationName(const int & aOperationIndex) const;
     const std::string & getOperationName(const std::string & aPerformerName) const;
+    boost::optional<OperationType> getOperationType(const std::string & aPerformerName) const;
 
     int getNumInputs(const int & aOperationIndex) const;
     int getNumInputs(const std::string & aPerformerName) const;

--- a/base/src/tools/Plato_OperationTypes.cpp
+++ b/base/src/tools/Plato_OperationTypes.cpp
@@ -1,0 +1,33 @@
+#include "Plato_OperationTypes.hpp"
+#include "Plato_EnumTable.hpp"
+#include "Plato_FreeFunctions.hpp"
+
+#include <cassert>
+
+namespace Plato
+{
+namespace 
+{
+const EnumTable<OperationType> kOperationTable({
+    {OperationType::kCriterionValue, "CriterionValue"},
+    {OperationType::kCriterionGradient, "CriterionGradient"},
+    {OperationType::kCriterionHessian, "CriterionHessian"}});
+}
+
+std::string operationTypeName(const OperationType aOperation)
+{
+    const boost::optional<std::string> tName = kOperationTable.toString(aOperation);
+    assert(tName);
+    return *tName;
+}
+
+boost::optional<OperationType> operationTypeIgnoreSpaces(const std::string& aOperation)
+{
+    return kOperationTable.toEnum(stripSpaces(aOperation));
+}
+
+boost::optional<OperationType> operationType(const std::string& aOperation)
+{
+    return kOperationTable.toEnum(aOperation);
+}
+}

--- a/base/src/tools/Plato_OperationTypes.hpp
+++ b/base/src/tools/Plato_OperationTypes.hpp
@@ -1,0 +1,25 @@
+#ifndef PLATO_OPERATIONTYPES_HPP_
+#define PLATO_OPERATIONTYPES_HPP_
+
+#include <string>
+
+#include <boost/optional.hpp>
+
+namespace Plato
+{
+enum class OperationType{
+  kCriterionValue,
+  kCriterionGradient,
+  kCriterionHessian
+};
+
+std::string operationTypeName(OperationType aOperation);
+/// Finds the matching enum, ignoring any spaces in @a aOperation. This is to be used when an
+/// operation is two or more words and spaces don't matter. Unfortunately, it's not smart enough
+/// to check for spaces only at the beginning, end, or between words, so `Crit er ionV alue` matches
+/// `kCriterionValue`.
+boost::optional<OperationType> operationTypeIgnoreSpaces(const std::string& aOperation);
+boost::optional<OperationType> operationType(const std::string& aOperation);
+}
+
+#endif

--- a/base/src/tools/unittest/CMakeLists.txt
+++ b/base/src/tools/unittest/CMakeLists.txt
@@ -4,7 +4,8 @@
 SET(PlatoTools_UnitTester_SRCS UnitMain.cpp
                                    ../Plato_ParseCSMUtilities.cpp
                                    Plato_Test_InputData.cpp
-                                   Plato_Test_Utilities.cpp)
+                                   Plato_Test_Utilities.cpp
+                                   Plato_Test_EnumTable.cpp)
 
 SET(PlatoTools_UnitTester_HDRS )
 

--- a/base/src/tools/unittest/Plato_Test_EnumTable.cpp
+++ b/base/src/tools/unittest/Plato_Test_EnumTable.cpp
@@ -1,0 +1,76 @@
+#include "Plato_EnumTable.hpp"
+#include "Plato_OperationTypes.hpp"
+
+#include <gtest/gtest.h>
+
+namespace PlatoTestEnumTable
+{
+
+TEST(EnumTable, Conversion)
+{
+    enum class Test{
+        kInky,
+        kPinky,
+        kBlinky,
+        kClyde,
+        kArbitraryEnumWithNoGhostlyRelation
+    };
+    const Plato::EnumTable<Test> kTestTable = {
+        {Test::kInky, "Inky"}, 
+        {Test::kPinky, "Pinky"},
+        {Test::kBlinky, "Blinky"},
+        {Test::kClyde, "Clyde"}};
+
+    // String to enum
+    ASSERT_TRUE(kTestTable.toEnum("Inky"));
+    ASSERT_TRUE(kTestTable.toEnum("Blinky"));
+    ASSERT_TRUE(kTestTable.toEnum("Pinky"));
+    ASSERT_TRUE(kTestTable.toEnum("Clyde"));
+
+    EXPECT_EQ(*kTestTable.toEnum("Inky"), Test::kInky);
+    EXPECT_EQ(*kTestTable.toEnum("Blinky"), Test::kBlinky);
+    EXPECT_EQ(*kTestTable.toEnum("Pinky"), Test::kPinky);
+    EXPECT_EQ(*kTestTable.toEnum("Clyde"), Test::kClyde);
+
+    EXPECT_FALSE(kTestTable.toEnum("clyde"));
+    EXPECT_FALSE(kTestTable.toEnum("Clyde "));
+    EXPECT_FALSE(kTestTable.toEnum("arbitrary string that has no ghostly relation"));
+
+    // Enum to string
+    ASSERT_TRUE(kTestTable.toString(Test::kInky));
+    ASSERT_TRUE(kTestTable.toString(Test::kBlinky));
+    ASSERT_TRUE(kTestTable.toString(Test::kPinky));
+    ASSERT_TRUE(kTestTable.toString(Test::kClyde));
+
+    EXPECT_EQ(*kTestTable.toString(Test::kInky), "Inky");
+    EXPECT_EQ(*kTestTable.toString(Test::kBlinky), "Blinky");
+    EXPECT_EQ(*kTestTable.toString(Test::kPinky), "Pinky");
+    EXPECT_EQ(*kTestTable.toString(Test::kClyde), "Clyde");
+
+    EXPECT_FALSE(kTestTable.toString(Test::kArbitraryEnumWithNoGhostlyRelation));
+}
+
+TEST(EnumTable, OperationType)
+{
+    EXPECT_EQ(Plato::operationTypeName(Plato::OperationType::kCriterionValue), "CriterionValue");
+    EXPECT_EQ(Plato::operationTypeName(Plato::OperationType::kCriterionGradient), "CriterionGradient");
+    EXPECT_EQ(Plato::operationTypeName(Plato::OperationType::kCriterionHessian), "CriterionHessian");
+
+    ASSERT_TRUE(Plato::operationType("CriterionValue"));
+    ASSERT_TRUE(Plato::operationType("CriterionGradient"));
+    ASSERT_TRUE(Plato::operationType("CriterionHessian"));
+
+    ASSERT_TRUE(Plato::operationTypeIgnoreSpaces(" Criterion  Value "));
+    ASSERT_TRUE(Plato::operationTypeIgnoreSpaces(" C  r iterionGradient "));
+    ASSERT_TRUE(Plato::operationTypeIgnoreSpaces("Criterion  Hessian"));
+
+    EXPECT_EQ(*Plato::operationType("CriterionValue"), Plato::OperationType::kCriterionValue);
+    EXPECT_EQ(*Plato::operationType("CriterionGradient"), Plato::OperationType::kCriterionGradient);
+    EXPECT_EQ(*Plato::operationType("CriterionHessian"), Plato::OperationType::kCriterionHessian);
+
+    EXPECT_EQ(*Plato::operationTypeIgnoreSpaces("  CriterionValue"), Plato::OperationType::kCriterionValue);
+    EXPECT_EQ(*Plato::operationTypeIgnoreSpaces("Criterio n G r a  dient"), Plato::OperationType::kCriterionGradient);
+    EXPECT_EQ(*Plato::operationTypeIgnoreSpaces("CriterionHessian"), Plato::OperationType::kCriterionHessian);
+}
+
+}

--- a/base/src/tools/unittest/Plato_Test_Utilities.cpp
+++ b/base/src/tools/unittest/Plato_Test_Utilities.cpp
@@ -1,4 +1,6 @@
 #include "Plato_ParseCSMUtilities.hpp"
+#include "Plato_FreeFunctions.hpp"
+
 #include <gtest/gtest.h>
 
 namespace PlatoTestUtilityFunctions
@@ -223,6 +225,13 @@ TEST(ParseCSMUtilities, getCorrectDescriptors)
     EXPECT_EQ(tDescriptors.size(), 2);
     EXPECT_EQ(tDescriptors[0], "Param1");
     EXPECT_EQ(tDescriptors[1], "Param2");
+}
+
+TEST(FreeFunctions, stripSpaces)
+{
+    EXPECT_EQ(Plato::stripSpaces("  Hello    World    "), "HelloWorld");
+    EXPECT_EQ(Plato::stripSpaces("HelloWorld"), "HelloWorld");
+    EXPECT_NE(Plato::stripSpaces("Hello World"), "Hello World");
 }
 
 } 

--- a/regression/Proxy_Rosenbrock_KSBC/interface.xml
+++ b/regression/Proxy_Rosenbrock_KSBC/interface.xml
@@ -70,7 +70,7 @@
 
   <Operation>
     <PerformerName>Proxy</PerformerName>
-    <Name>Objective</Name>
+    <Name>Criterion Value</Name>
     <Input>
       <ArgumentName>Controls</ArgumentName>
       <SharedDataName>Control</SharedDataName>
@@ -95,7 +95,7 @@
   
   <Operation>
     <PerformerName>Proxy</PerformerName>
-    <Name>Gradient</Name>
+    <Name>Criterion Gradient</Name>
     <Input>
       <ArgumentName>Controls</ArgumentName>
       <SharedDataName>Control</SharedDataName>
@@ -123,7 +123,7 @@
   
   <Operation>
     <PerformerName>Proxy</PerformerName>
-    <Name>HessianTimesVector</Name>
+    <Name>Criterion Hessian</Name>
     <Input>
       <ArgumentName>Controls</ArgumentName>
       <SharedDataName>Control</SharedDataName>


### PR DESCRIPTION
Two main additions:
* A new derived class of Application, intended for its derived classes to implement a more constrained interface only involving criterion calculations, value, gradient, and Hessian.
* An EnumTable class to help convert strings to enums, so that we can later replace internal strings w/ enums. 

These changes are only applied to the proxy Rosenbrock app.

TO-5179