### PR TITLE
remove MPI dependency from libPlatoGeometryImpl.so

### DIFF
--- a/apps/esp/PlatoESPApp.hpp
+++ b/apps/esp/PlatoESPApp.hpp
@@ -42,10 +42,13 @@
 
 #pragma once
 
+#include <mpi.h>
+
 #include "Plato_ESP.hpp"
 #include "Plato_LocalOperation.hpp"
 #include "Plato_Application.hpp"
 #include "Plato_TimersTree.hpp"
+#include "Plato_InputData.hpp"
 
 typedef double ScalarType;
 typedef std::vector<ScalarType> ScalarVector;

--- a/base/src/geometry/ESP/CMakeLists.txt
+++ b/base/src/geometry/ESP/CMakeLists.txt
@@ -18,7 +18,6 @@ set(LIB_NAMES ${LIB_NAMES} ${LIB_NAME})
 
 set(${LIB_NAME}_SOURCES
        Plato_ESP_Impl.cpp
-       Plato_ESP.cpp
        bodyTess.c
    )
 

--- a/base/src/geometry/ESP/Plato_ESP.cpp
+++ b/base/src/geometry/ESP/Plato_ESP.cpp
@@ -42,6 +42,7 @@
 
 #include "Plato_ESP.hpp"
 #include "Plato_KokkosTypes.hpp"
+#include "Plato_Exceptions.hpp"
 
 namespace Plato {
 namespace Geometry {
@@ -73,6 +74,12 @@ ScalarType ESP<ScalarType,ScalarVectorType>::sensitivity(int aParameterIndex, Sc
         tDfDp += tSensitivity[k]*aGradientX[k];
     }
     return tDfDp;
+}
+
+template <typename ScalarType, typename ScalarVectorType>
+void ESP<ScalarType,ScalarVectorType>::throwWithError(std::string aError)
+{
+    throw Plato::ParsingException(aError);
 }
 
 template <typename ScalarType, typename ScalarVectorType>

--- a/base/src/geometry/ESP/Plato_ESP.hpp
+++ b/base/src/geometry/ESP/Plato_ESP.hpp
@@ -59,8 +59,6 @@
 #include <fstream>
 #include <cctype>
 
-#include "Plato_Exceptions.hpp"
-
 namespace Plato {
 namespace Geometry {
 
@@ -89,6 +87,9 @@ class ESP
     decltype(mSensitivity) getSensitivities(){ return mSensitivity; }
 
     ScalarType sensitivity(int aParameterIndex, ScalarVectorType aGradientX);
+
+protected:
+    virtual void throwWithError(std::string aError);
 
   private:
     void readNames();

--- a/base/src/geometry/ESP/Plato_ESP_Impl.cpp
+++ b/base/src/geometry/ESP/Plato_ESP_Impl.cpp
@@ -46,7 +46,7 @@ private:
     void *model = nullptr;
     modl_T *modelT = nullptr;
 
-    void throwWithError(std::string aError);
+    void throwWithError(std::string aError) override;
     void tesselate();
     ScalarType computeSensitivity(VectorType& aDXDp);
     void buildGeometryAndGetBodies();
@@ -299,7 +299,7 @@ void ESPImpl<ScalarType,ScalarVectorType>::throwWithError(std::string aError)
 {
     safeFreeOCSM();
     safeFreeContext();
-    throw Plato::ParsingException(aError);
+    ESP<ScalarType,ScalarVectorType>::throwWithError(aError);
 }
 
 template class ESPImpl<double,std::vector<double>>;


### PR DESCRIPTION
To actually build without MPI, I did the following:

make VERBOSE=1 > build.log 2>&1
grep Plato_ESP_Impl build.log > build_without_mpi.sh ./build_without_mpi.sh

We could try to work this process into CMake or some automated script if it turns out to be useful