### PR TITLE
changes 'which' to 'command -v'

### DIFF
--- a/share/plato-cli
+++ b/share/plato-cli
@@ -26,7 +26,7 @@ def source_dir():
   return str(parent)
 
 def is_executable(exeName):
-  command = 'which ' + exeName
+  command = 'command -v ' + exeName
   try:
     response = subprocess.check_output(command.split())
   except:


### PR DESCRIPTION
'command -v' more reliably finds executables than 'which' on some systems