### PR TITLE
fixes "command -v" syntax

### DIFF
--- a/share/plato-cli
+++ b/share/plato-cli
@@ -26,9 +26,9 @@ def source_dir():
   return str(parent)
 
 def is_executable(exeName):
-  command = 'command -v ' + exeName
+  command = ['bash', '-c', 'command -v ' + exeName]
   try:
-    response = subprocess.check_output(command.split())
+    response = subprocess.check_output(command)
   except:
     return False
   else:


### PR DESCRIPTION
command -v is not an executable file, it is a shell command, so it must by run by a shell